### PR TITLE
New features: altdisk, health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# patch_mgmt
+# Updates in a NIM environment
 
 # AIX for Ansible
 
@@ -110,20 +110,78 @@ Must be described in yaml format with the following parameters:
 
 ```
 
-### updateios
+### UPDATEIOS
 
-Updates the Virtual I/O Server to the latest maintenace level.
+Updates the Virtual I/O Server.
 
-In the aix_updateios module is:
-
+Must be described in yaml format with the following parameters:
 
 ```yaml
-    aix_updateios:
-      target:           specify the target VIOS
-      lpp_source:       specify the resource that will provide the installation images
-      filesets:         specify a list of file sets to remove from the target
-      installp_bundle:  specify the resource that lists file sets to remove on the target
-      accept_licenses:  specify whether the software licenses should be automatically accepted during the installation
-      updateios_flag:   specify the flag that tells updateios what operation to perform on the VIOS
-      preview:          specify a preview operation for the updateios operation
+    aix_nim_updateios:
+      targets:          a list of VIOS to act upon depending on the "action" specified;
+                        to perform an update on dual VIOS, specify the list as a tuple
+                        with the following format : "(gdrh9v1, gdrh9v2) (gdrh10v1, gdrh10v2)”;
+                        to specify a single VIOS, use the following format : "(gdrh11v0)".
+      lpp_source:       the resource that will provide the installation images;
+                        required in case of "install".
+      filesets:         a list of filesets to act upon on each of the targets
+                        depending on the "action" specified.
+      installp_bundle:  the resource that lists the filesets to act upon on each of the targets
+                        depending on the "action" specified;
+                        "filesets" and "installp_bundle" are mutually exclusive.
+      accept_licenses:  specify whether the software licenses should be automatically accepted
+                        during the installation;
+                        default value: "yes".
+      action:           the operation to perform on the VIOS;
+                        possible values are : "install", "commit", "reject", "cleanup" and "remove";
+                        "reject" is not supported by the latest version of updateios.
+      preview:          specify that only a preview operation will be performed
+                        (the action itself will not be performed);
+                        default value: "yes".
+      time_limit:       when this parameter is specified, before starting the updateios action
+                        specified on a new VIOS in the "targets" list, the actual date is compared
+                        to this parameter value; if it is greater then the task is stopped;
+                        the format is mm/dd/yyyy hh:mm
+```
+
+### VIOS HEALTH CHECK
+
+Performs a health check of VIOS before updating.
+
+Requires vioshc.py as a prerequisite.
+vioshc.py is available on https://github.com/aixoss/vios-health-checker.
+
+Must be described in yaml format with the following parameters:
+
+```yaml
+    aix_nim_vios_hc:
+      targets:          a list of VIOS to act upon depending on the "action" specified;
+                        to perform a health check on dual VIOS, specify the list as a tuple
+                        with the following format : "(gdrh9v1, gdrh9v2) (gdrh10v1, gdrh10v2)”;
+                        to specify a single VIOS, use the following format : "(gdrh11v0)".
+      action:           the operation to perform on the VIOS;
+                        must be set to "health_check".
+
+```
+
+### ALTERNATE DISK COPY on a VIOS
+
+Performs alternate disk copy on a VIOS (before update).
+
+Must be described in yaml format with the following parameters:
+
+```yaml
+    aix_nim_vios_alt_disk:
+      targets:          a list of VIOS to act upon depending on the "action" specified;
+                        use a tuple format with the 1st element the VIOS and the 2nd element
+                        the disk used for the alternate disk copy;
+                        for a dual VIOS, the format will look like : "(vios1,disk1,vios2,disk2)";
+                        for a single VIOS, the format will look like : "(vios1,disk1)".
+      action:           the operation to perform on the VIOS;
+                        2 possible values : "alt_disk_copy" and "alt_disk_clean".
+      time_limit:       when this parameter is specified, before starting the updateios action
+                        specified on a new VIOS in the "targets" list, the actual date is compared
+                        to this parameter value; if it is greater then the task is stopped
+                        the format is mm/dd/yyyy hh:mm
+
 ```

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -271,8 +271,8 @@ def check_vios_targets(targets):
         tuple_len = len(tuple_elts)
 
         if tuple_len != 2 and tuple_len != 4:
-            logging.error('Malformed VIOS targets {}. Should be a 2 or 4 elements tuple'. \
-                          format(tuple_elts, tuple_len, targets))
+            logging.error('Malformed VIOS targets {}. Tuple {} should be a 2 or 4 elements.'. \
+                          format(targets, tuple_elts))
             return None
 
         # check vios not already exists in the target list
@@ -289,10 +289,12 @@ def check_vios_targets(targets):
                           format(targets))
             return None
 
-        # check vios is knowed by the NIM master - if not ignore it
+        # check vios is known by the NIM master - if not ignore it
         # because it can concern an other ansible host (nim master)
         if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
            (tuple_len == 4 and  tuple_elts[2] not in NIM_NODE['nim_vios']):
+            logging.debug('skipping {} as VIOS not known by the NIM master.'. \
+                        format(vios_tuple))
             continue
 
         # fill vios_list dictionnary
@@ -857,10 +859,6 @@ if __name__ == '__main__':
     else:
         description = "Perform an alternate disk operation: {} request".format(action)
 
-    if module.params['description']:
-        description = module.params['description']
-    else:
-        description = "vios alt_disk - operation: {} request".format(action)
     PARAMS['action'] = action
     PARAMS['targets'] = targets
     PARAMS['Description'] = description
@@ -875,7 +873,7 @@ if __name__ == '__main__':
         VARS['log_file'] = '/tmp/ansible_vios_alt_disk_debug.log'
 
     # Open log file
-    DEBUG_DATA.append('Logging file: {}'.format(VARS['log_file']))
+    DEBUG_DATA.append('Log file: {}'.format(VARS['log_file']))
     logging.basicConfig(filename="{}".format(VARS['log_file']), format= \
         '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
         level=logging.DEBUG)
@@ -889,7 +887,9 @@ if __name__ == '__main__':
     targets_altdisk_status = {}
     target_list = []
 
+    # =========================================================================
     # build nim node info
+    # =========================================================================
     if module.params['nim_node']:
         NIM_NODE = module.params['nim_node']
     else:
@@ -920,7 +920,6 @@ if __name__ == '__main__':
         OUTPUT.append('    Warning: Empty target list')
         logging.warn('Empty target list for targets {}'. \
                       format(targets))
-
     else:
         target_list = ret
         OUTPUT.append('    Targets list: {}'.format(target_list))

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -1,0 +1,961 @@
+#!/usr/bin/python
+#
+# Copyright 2017, International Business Machines Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+######################################################################
+
+import os
+import re
+import glob
+import shutil
+import subprocess
+import threading
+import time
+import logging
+import string
+
+# Ansible module 'boilerplate'
+from ansible.module_utils.basic import *
+
+
+DOCUMENTATION = """
+---
+module: aix_nim_vios_alt_disk
+short_description: "Copy the rootvg to an alternate disk or cleanup an existing one"
+author: "Patrice Jacquin, Vianney Robin"
+version_added: "1.0.0"
+requirements: [ AIX ]
+
+TBC - Does proc.communicate set the return code with the command's return code? (seems to get 0 even we get "command not found" in stderr) 
+
+Note - alt_disk_copy only backs up mounted file systems. Mount all file systems that you want to back up.
+     - copy is performed only on one alternate hdisk even if the rootvg contains multiple hdisks
+     - error if several altinst_rootvg exist for cleanup operation in automatic mode
+"""
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def exec_cmd(cmd, module):
+    """
+    Execute the given command
+        - cmd     array of the command parameters
+        - module  the module variable
+
+    In case of error set an error massage and fails the module
+
+    return
+        - ret_code  (0)
+        - std_out   output of the command
+    """
+
+    global DEBUG_DATA
+
+    std_out = ''
+    std_err = ''
+
+    logging.debug('exec command:{}'.format(cmd))
+    try:
+        std_out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exc:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+               format(cmd, exc.cmd, exc.output, exc.returncode)
+        # module.fail_json(msg=msg)
+        # TBC
+        return (1, " ")
+    except Exception as exc:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+               format(cmd, exc.args, std_out, std_err)
+        # module.fail_json(msg=msg)
+        return (1, " ")
+
+    # DEBUG
+    DEBUG_DATA.append('exec command:{}'.format(cmd))
+    DEBUG_DATA.append('exec command stderr:{}'.format(std_err))
+    logging.debug('exec command stderr:{}'.format(std_err))
+    logging.debug('exec command output:{}'.format(std_out))
+    # --------------------------------------------------------
+
+    return (0, std_out)
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_hmc_info(module):
+    """
+    Get the hmc info on the nim master, and get their login/passwd
+
+    fill the hmc_dic passed in parameter (filled with the login/passwd value)
+    
+    return a dic with hmc info
+    """
+    std_out = ''
+    std_err = ''
+    info_hash = {}
+
+    cmd = ['lsnim', '-t', 'hmc', '-l']
+
+    try:
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    obj_key = ''
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(\S+):", line)
+        # HMC name
+        if match_key:
+            obj_key = match_key.group(1)
+            info_hash[obj_key] = {}
+            continue
+
+        match_cstate = re.match(r"^\s+Cstate\s+=\s+(.*)$", line)
+        if match_cstate:
+            cstate = match_cstate.group(1)
+            info_hash[obj_key]['cstate'] = cstate
+            continue
+
+        match_key = re.match(r"^\s+passwd_file\s+=\s+(.*)$", line)
+        if match_key:
+            info_hash[obj_key]['passwd_file'] = match_key.group(1)
+            continue
+
+        match_key = re.match(r"^\s+login\s+=\s+(.*)$", line)
+        if match_key:
+            info_hash[obj_key]['login'] = match_key.group(1)
+            continue
+
+        match_key = re.match(r"^\s+if1\s*=\s*\S+\s*(\S*)\s*.*$", line)
+        if match_key:
+            info_hash[obj_key]['ip'] = match_key.group(1)
+            continue
+
+    return info_hash
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_nim_clients_info(module, lpar_type):
+    """
+    Get the list of the lpar (standalones or vios) defined on the nim master, and get their
+    cstate.
+
+    return the list of the name of the lpar objects defined on the
+           nim master and their associated cstate value
+    """
+    std_out = ''
+    std_err = ''
+    info_hash = {}
+
+    cmd = ['lsnim', '-t', lpar_type, '-l']
+
+    try:
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    # lpar name and associated Cstate
+    obj_key = ""
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(\S+):", line)
+        if match_key:
+            obj_key = match_key.group(1)
+            info_hash[obj_key] = {}
+            continue
+
+        match_cstate = re.match(r"^\s+Cstate\s+=\s+(.*)$", line)
+        if match_cstate:
+            cstate = match_cstate.group(1)
+            info_hash[obj_key]['cstate'] = cstate
+            continue
+
+        # For VIOS store the management profile
+        if lpar_type == 'vios':
+            match_mgmtprof = re.match(r"^\s+mgmt_profile1\s+=\s+(.*)$", line)
+            if match_mgmtprof:
+                mgmt_elts = match_mgmtprof.group(1).split()
+                if len(mgmt_elts) == 3:
+                    info_hash[obj_key]['mgmt_hmc_id'] = mgmt_elts[0]
+                    info_hash[obj_key]['mgmt_vios_id'] = mgmt_elts[1]
+                    info_hash[obj_key]['mgmt_cec_serial'] = mgmt_elts[2]
+                else:
+                    logging.warning('WARNING: VIOS {} management profile has not 3 elements: {}'. \
+                                  format(obj_key, match_mgmtprof.group(1)))
+                continue
+
+            match_if = re.match(r"^\s+if1\s+=\s+\S+\s+(\S+)\s+.*$", line) 
+            if match_if:
+                info_hash[obj_key]['vios_ip'] = match_if.group(1)
+                continue
+
+    return info_hash
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def build_nim_node(module):
+    """
+    build the nim node containing the nim vios and hmcinfo.
+
+    arguments:
+        None
+
+    return:
+        None
+    """
+
+    global NIM_NODE
+
+    # =========================================================================
+    # Build hmc info list
+    # =========================================================================
+    nim_hmc = {}
+    nim_hmc = get_hmc_info(module)
+
+    NIM_NODE['nim_hmc'] = nim_hmc
+    logging.debug('NIM HMC: {}'.format(nim_hmc))
+
+    # =========================================================================
+    # Build vios info list
+    # =========================================================================
+    nim_vios = {}
+    nim_vios = get_nim_clients_info(module, 'vios')
+
+    NIM_NODE['nim_vios'] = nim_vios
+    logging.debug('NIM VIOS: {}'.format(nim_vios))
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def check_vios_targets(targets):
+    """
+    check the list of the vios targets.
+
+    a target name could be of the following forms:
+        (vios1, altdisk1, vios2, altdisk2) (...)
+        (vios1, altdisk1) (vios2, altdisk2) (...)
+    a altdisk can be omitted if one wants to use the automatic discovery
+    in that case, the first available disk with a enough space will be taken
+
+    arguments:
+        targets (str): list of tuple of NIM name of vios machine and 
+                           associated alternate disk
+
+    return: the list of the existing vios tuple matching the target list
+    """
+    global NIM_NODE
+
+    vios_list = {}
+    vios_list_tuples_res = []
+    vios_list_tuples = targets.replace(" ", "").split('(')
+
+    # ===========================================
+    # Build targets list
+    # ===========================================
+    for vios_tuple in vios_list_tuples[1:]:
+
+        logging.debug('vios_tuple: {}'.format(vios_tuple))
+
+        tuple_elts = list(vios_tuple[:-1].split(','))
+        tuple_len = len(tuple_elts)
+
+        if tuple_len != 2 and tuple_len != 4:
+            logging.error('Malformed VIOS targets {}. Should be a 2 or 4 elements tuple'. \
+                          format(tuple_elts, tuple_len, targets))
+            return None
+
+        # check vios not already exists in the target list
+        if tuple_elts[0] in vios_list or \
+           (tuple_len == 4 and (tuple_elts[2] in vios_list or \
+                                tuple_elts[0] == tuple_elts[2])):
+            logging.error('Malformed VIOS targets {}. Duplicated VIOS'. \
+                          format(targets))
+            return None
+
+        # check if duplicate alt_disk value
+        if tuple_len == 4 and tuple_elts[1] == tuple_elts[3]:
+            logging.error('Malformed VIOS targets {}. Duplicated alternate disks'. \
+                          format(targets))
+            return None
+
+        # check vios is knowed by the NIM master - if not ignore it
+        # because it can concern an other ansible host (nim master)
+        if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
+           (tuple_len == 4 and  tuple_elts[2] not in NIM_NODE['nim_vios']):
+            continue
+
+        # fill vios_list dictionnary
+        if tuple_len == 4:
+            vios_list[tuple_elts[0]] = tuple_elts[1]
+            vios_list[tuple_elts[2]] = tuple_elts[3]
+            # vios_list = vios_list.extend([tuple_elts[0], tuple_elts[1]])
+            my_tuple = (tuple_elts[0], tuple_elts[1], tuple_elts[2], \
+                        tuple_elts[3])
+            vios_list_tuples_res.append(tuple(my_tuple))
+        else:
+            vios_list[tuple_elts[0]] = tuple_elts[1]
+            # vios_list.append(tuple_elts[0])
+            my_tuple = (tuple_elts[0],tuple_elts[1])
+            vios_list_tuples_res.append(tuple(my_tuple))
+
+    return vios_list_tuples_res
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_pvs(module, vios):
+    """
+    get the list of PV on the VIOS
+
+    return: dictionnary with free PVs information
+    """
+    global NIM_NODE
+    global OUTPUT
+
+    logging.debug('vios: {}'.format(vios))
+
+    pvs = {}
+
+    cmd = "/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} '/usr/ios/cli/ioscli lspv'". \
+            format(NIM_NODE['nim_vios'][vios]['vios_ip'])
+    try:
+        (std_out, std_err) = ("", "")
+        proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    if proc.returncode != 0:
+        OUTPUT.append('    Failed to get the PV list on {}, lspv returns: {} {}'. \
+                format(vios, proc.returncode, std_err))
+        logging.error('Failed to get the PV list on {}, lspv returns: {} {}'. \
+                format(vios, proc.returncode, std_err))
+        return None
+
+    # NAME             PVID                                 VG               STATUS
+    # hdisk0           000018fa3b12f5cb                     rootvg           active
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(hdisk\S+)\s+(\S+)\s+(\S+)\s*(\S*)", line)
+        if match_key:
+            pvs[match_key.group(1)] = {}
+            pvs[match_key.group(1)]['pvid'] = match_key.group(2)
+            pvs[match_key.group(1)]['vg'] = match_key.group(3)
+            pvs[match_key.group(1)]['status'] = match_key.group(4)
+    
+    logging.debug('List of PVs:')
+    for key in pvs.keys():
+        logging.debug('    pvs[{}]: {}'.format(key, pvs[key]))
+
+    return pvs
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_free_pvs(module, vios):
+    """
+    get the list of free PV on the VIOS
+
+    return: dictionnary with free PVs information
+    """
+    global NIM_NODE
+    global OUTPUT
+
+    logging.debug('vios: {}'.format(vios))
+
+    free_pvs = {}
+
+    cmd = "/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} '/usr/ios/cli/ioscli lspv -free'". \
+            format(NIM_NODE['nim_vios'][vios]['vios_ip'])
+    try:
+        (std_out, std_err) = ("", "")
+        proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    if proc.returncode != 0:
+        OUTPUT.append('    Failed to get the list of free PV on {}: {}'. \
+                format(vios, proc.returncode, std_err))
+        logging.error('Failed to get the list of free PVs on {}, lspv returns: {} {}'. \
+                format(vios, proc.returncode, std_err))
+        return None
+
+    # NAME            PVID                                SIZE(megabytes)
+    # hdiskX          none                                572325
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(hdisk\S+)\s+(\S+)\s+(\S+)", line)
+        if match_key:
+            free_pvs[match_key.group(1)] = {}
+            free_pvs[match_key.group(1)]['pvid'] = match_key.group(2)
+            free_pvs[match_key.group(1)]['size'] = int(match_key.group(3))
+
+    logging.debug('List of available PVs:')
+    for key in free_pvs.keys():
+        logging.debug('    free_pvs[{}]: {}'.format(key, free_pvs[key]))
+
+    return free_pvs
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_vg_size(module, vios, vg_name):
+    """
+    get the size in MB of the VG on the VIOS
+
+    return:
+        size of the vg otherwise
+        -1   upon error
+    """
+    global NIM_NODE
+    global OUTPUT
+
+    logging.debug('vios: {}'.format(vios))
+
+    vg_size = -1
+
+    cmd = "/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} '/usr/ios/cli/ioscli lsvg {}'". \
+            format(NIM_NODE['nim_vios'][vios]['vios_ip'], vg_name)
+    try:
+        (std_out, std_err) = ("", "")
+        proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    if proc.returncode != 0:
+        OUTPUT.append('    Failed to get the {} VG size on {}, lsvg returns: {} {}'. \
+                format(vg_name, vios, proc.returncode, std_err))
+        logging.error('Failed to get the {} VG size on {}, lsvg returns: {} {}'. \
+                format(vg_name, vios, proc.returncode, std_err))
+        return -1
+
+    # parse lsvg outpout to get the size in megabytes:
+    # VG PERMISSION:      read/write               TOTAL PPs:      558 (285696 megabytes)
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r".*TOTAL PPs:\s+\d+\s+\((\d+)\s+megabytes\).*", line)
+        if match_key:
+            vg_size = int(match_key.group(1))
+    
+    if vg_size == -1:
+        OUTPUT.append('    Failed to get the {} VG size on {}, parsing error'. \
+                format(vg_name, vios))
+        logging.error('Failed to get the {} VG size on {}, parsing error'. \
+                format(vg_name, vios))
+        return -1
+
+    return vg_size
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def find_valid_altdisk(module, action, vios, vios_dict, vios_key, altdisk_op_tab, err_label):
+    """
+    find a valid alternate disk that
+    - exists,
+    - is not part of a VG
+    and so can be used.
+
+    sets the altdisk_op_tab acordingly:
+        altdisk_op_tab[vios_key] = "FAILURE-ALTDC[12] <error message>"
+        altdisk_op_tab[vios_key] = "SUCCESS-ALTDC"
+
+    return:
+        the disk name that can be used
+        None otherwise
+    """
+    global NIM_NODE
+    global OUTPUT
+
+    logging.debug('action: {}, vios: {}, vios_dict[{}]: {}, vios_key: {}'. \
+            format(action, vios, vios, vios_dict[vios], vios_key))
+
+    OUTPUT.append('    Check the alternate disk {} on {}'.format(vios_dict[vios], vios))
+    pvs = {}
+
+    if action == 'alt_disk_copy':
+
+        pvs = get_free_pvs(module, vios)
+        if (pvs is None) or (not pvs):
+            altdisk_op_tab[vios_key] = "{} to get the list of free PVs on {}". \
+                    format(err_label, vios)
+            return None
+
+        rootvg_size = get_vg_size(module, vios, "rootvg")
+        if rootvg_size <= 0:
+            altdisk_op_tab[vios_key] = "{} to get the rootvg size on {}". \
+                    format(err_label, vios)
+            return None
+        logging.debug('rootvg size is: {} MB'.format(rootvg_size))
+
+        # in auto mode, find the first alternate disk available
+        if vios_dict[vios] == "":
+            for hdisk in pvs.keys():
+                if pvs[hdisk]['size'] >= rootvg_size:
+                    vios_dict[vios] = hdisk
+                    return hdisk
+            altdisk_op_tab[vios_key] = "{} to find an alternate disk {} on {}". \
+                    format(err_label, vios_dict[vios], vios)
+            OUTPUT.append('    No available alternate disk with size greater than {} MB found on {}'. \
+                    format(rootvg_size, vios))
+            logging.error('No available alternate disk with size greater than {} MB found on {}'. \
+                    format(rootvg_size, vios))
+            return None
+
+        # check the specified hdisk is large enough
+        if pvs.has_key(vios_dict[vios]):
+            if pvs[vios_dict[vios]]['size'] >= rootvg_size:
+                return vios_dict[vios]
+            else:
+                altdisk_op_tab[vios_key] = "{} alternate disk {} too small on {}". \
+                        format(err_label, vios_dict[vios], vios)
+                logging.error('Alternate disk {} too small ({} < {}) on {}.'. \
+                        format(vios_dict[vios], pvs[vios_dict[vios]]['size'], rootvg_size, vios))
+                return None
+        else:
+            altdisk_op_tab[vios_key] = "{} disk {} is not available on {}". \
+                    format(err_label, vios_dict[vios], vios)
+            OUTPUT.append('    Alternate disk {} is not available on {}'. \
+                    format(vios_dict[vios], vios))
+            logging.error('Alternate disk {} is either not found or not available on {}'. \
+                    format(vios_dict[vios], vios))
+            return None
+
+    elif action == 'alt_disk_clean':
+
+        pvs = get_pvs(module, vios)
+        if (pvs is None) or (not pvs):
+            altdisk_op_tab[vios_key] = "{} to get the list of PVs on {}". \
+                    format(err_label, vios)
+            return None
+
+        if vios_dict[vios] != "":
+            if pvs.has_key(vios_dict[vios]) and pvs[vios_dict[vios]]['vg'] == "altinst_rootvg":
+                return vios_dict[vios]
+            else:
+                altdisk_op_tab[vios_key] = "{} disk {} is not an alternate install rootvg on {}". \
+                        format(err_label, vios_dict[vios], vios)
+                OUTPUT.append('    Specified disk {} is not an alternate install rootvg on {}'. \
+                        format(vios_dict[vios], vios))
+                logging.error('Specified disk {} is not an alternate install rootvg on {}'. \
+                        format(vios_dict[vios], vios))
+                return None
+        else:
+            # check there is one and only one alternate install rootvg
+            for hdisk in pvs.keys():
+                if pvs[hdisk]['vg'] == "altinst_rootvg":
+                    if vios_dict[vios]:
+                        altdisk_op_tab[vios_key] = "{} there are several alternate install rootvg on {}". \
+                                format(err_label, vios)
+                        OUTPUT.append('    There are several alternate install rootvg on {}: {} and {}'. \
+                                format(vios, vios_dict[vios], hdisk))
+                        logging.error('There are several alternate install rootvg on {}: {} and {}'. \
+                                format(vios, vios_dict[vios], hdisk))
+                        vios_dict[vios] = ""    # reset previously set hdisk
+                        return None
+                    else:
+                        vios_dict[vios] = hdisk
+            return vios_dict[vios]
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def wait_altdisk_install(module, vios, vios_dict, vios_key, altdisk_op_tab, err_label):
+    """
+    wait for the alternate disk copy operation to finish.
+
+    when alt_disk_install operation ends the NIM object state changes
+    from "a client is being prepared for alt_disk_install" or
+         "alt_disk_install operation is being performed"
+    to   "ready for NIM operation"
+
+    return:
+        -1  if timedout before alt_disk_install ends
+        0   if the alt_disk_install operation ends with success
+        1   if the alt_disk_install operation ends with error
+    """
+    global OUTPUT
+
+    logging.debug('vios: {}, vios_dict[{}]: {}, vios_key: {}'. \
+            format(vios, vios, vios_dict[vios], vios_key))
+
+    logging.info('Waiting completion of alt_disk copy {} on {}...'. \
+            format(vios_dict[vios], vios))
+
+    operation_ends = -1
+    wait_time = 0
+
+    # if there is no progress in nim operation "info" attribute for more than
+    # 30 minutes we time out: 180 * 10s = 30 min
+    check_count = 0 
+    nim_info_prev = "___"   # this info should not appears in nim info attribute
+    while check_count <= 180:
+        time.sleep(10)
+        wait_time += 10
+
+        cmd = ['lsnim', '-Z', '-a',  'Cstate', '-a',  'info', '-a',  'Cstate_result', vios]
+        try:
+            (std_out, std_err) = ("", "")
+            proc = subprocess.Popen(cmd, shell=False, stdin=None, \
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            (std_out, std_err) = proc.communicate()
+        except Exception as excep:
+            msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                    format(cmd, excep.args, std_out, std_err)
+            module.fail_json(msg=msg)
+
+        if proc.returncode != 0:
+            altdisk_op_tab[vios_key] = "{} to get the NIM state for {}".format(err_label, vios)
+            OUTPUT.append('    Failed to get the NIM state for {}: {}'. \
+                    format(vios, std_err))
+            logging.error('Failed to get the NIM state for {}: {}'. \
+                    format(vios, std_err))
+            break
+
+        # info attribute (that appears in 3rd possition) can be empty. So stdout looks like:
+        # #name:Cstate:info:Cstate_result:
+        # <viosName>:ready for a NIM operation:success
+        # <viosName>:alt_disk_install operation is being performed:Creating logical volume alt_hd2.:success:
+        # <viosName>:ready for a NIM operation:0505-126 alt_disk_install- target disk hdisk2 has a volume group assigned to it.:failure:
+        nim_status = std_out.rstrip().split('\n')[1].split(':')
+        nim_Cstate = nim_status[1]
+        if len(nim_status) == 4 and (string.lower(nim_status[2]) == "success" or string.lower(nim_status[2].lower()) == "failure"):
+            nim_result = string.lower(nim_status[2])
+        else:
+            nim_info = nim_status[2]
+            nim_result = string.lower(nim_status[3])
+
+        if nim_Cstate == "ready for a NIM operation":
+            logging.info('alt_disk copy operation on {} ended with nim_result: {}'.format(vios, nim_result))
+            if nim_result != "success":
+                altdisk_op_tab[vios_key] = "{} to perform alt_disk copy on {} {}".format(err_label, vios, nim_info)
+                OUTPUT.append('    Failed to perform alt_disk copy on {}: {}'. \
+                        format(vios, nim_info))
+                logging.error('Failed to perform alt_disk copy on {}: {}'. \
+                        format(vios, nim_info))
+                return 1
+            else:
+                return 0
+        else:
+            if nim_info_prev == nim_info:
+                check_count += 1
+            else:
+                nim_info_prev = nim_info
+                check_count = 0
+
+        if wait_time % 60 == 0:
+            logging.info('Waiting completion of alt_disk copy {} on {}... {} minute(s)'. \
+                format(vios_dict[vios], vios, wait_time / 60))
+
+    # timed out before the end of alt_disk_install
+    altdisk_op_tab[vios_key] = "{} alternate disk copy of {} blocked on {}: NIM operation blocked". \
+        format(err_label, vios, nim_info)
+    OUTPUT.append('    Alternate disk copy of {} blocked on {}: {}'.format(vios_dict[vios], vios, nim_info))
+    logging.error('Alternate disk copy of {} blocked on {}: {}'.format(vios_dict[vios], vios, nim_info))
+
+    return -1
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def alt_disk_action(module, action, targets, vios_status):
+    """
+    alt_dik_copy / alt_disk_clean operation
+    
+    For each VIOS tuple,
+    - retrieve the previous status if any (looking for SUCCESS-HC and SUCCESS-UPDT1)
+    - for each VIOS of the tuple, find and valid the hdisk for the operation
+    - perform the alt disk copy or cleanup operation
+    - wait for the copy to finish
+
+    return: dictionary containing the altdisk status for each vios tuple
+        altdisk_op_tab[vios_key] = "FAILURE-NO-PREV-STATUS"
+        altdisk_op_tab[vios_key] = "FAILURE-ALTDC[12] <error message>"
+        altdisk_op_tab[vios_key] = "SUCCESS-ALTDC"
+    """
+    global NIM_NODE
+    global OUTPUT
+
+    logging.debug('action: {}, targets: {}, vios_status: {}'. \
+                  format(action, targets, vios_status))
+
+    altdisk_op_tab = {}
+    vios_key = []
+    for target_tuple in targets:
+        logging.debug('action: {} for target_tuple: {}'. \
+                      format(action, target_tuple))
+
+        vios_dict = {}
+        tup_len = len(target_tuple)
+        vios1 = target_tuple[0]
+        vios2 = ""
+        vios_dict[vios1] = target_tuple[1]
+        if tup_len == 4:
+            vios2 = target_tuple[2]
+            vios_dict[vios2] = target_tuple[3]
+            vios_key = "{}-{}".format(vios1, vios2)
+        else:
+            vios_key = vios1
+
+        # if health check status is known, check the vios tuple has passed
+        # the health check successfuly
+        if not (vios_status is None):
+            if vios_key not in vios_status:
+                altdisk_op_tab[vios_key] = "FAILURE-NO-PREV-STATUS"
+                OUTPUT.append("    {} vioses skiped (no previous status found)". \
+                               format(vios_key))
+                logging.warn("{} vioses skiped (no previous status found)". \
+                              format(vios_key)) 
+                continue
+
+            elif vios_status[vios_key] != 'SUCCESS-HC' and vios_status[vios_key] != 'SUCCESS-UPDT1':
+                altdisk_op_tab[vios_key] = vios_status[vios_key]
+                OUTPUT.append("    {} vioses skiped (health check failed)". \
+                               format(vios_key))
+                logging.warn("{} vioses skiped (health check failed)". \
+                              format(vios_key)) 
+                continue
+
+        altdisk_op_tab[vios_key] = "SUCCESS-ALTDC"
+
+        # TBC - Uncomment for testing without effective altdisk operation
+        # continue
+        
+        logging.debug('vios_key: {}'.format(vios_key))
+
+        for vios in vios_dict.keys():
+
+            # set the error label to be used in sub routines
+            if action == 'alt_disk_copy':
+                err_label = "FAILURE-ALTDCOPY1"
+                if vios == vios2:
+                    err_label = "FAILURE-ALTDCOPY2"
+            elif action == 'alt_disk_clean':
+                err_label = "FAILURE-ALTDCLEAN1"
+                if vios == vios2:
+                    err_label = "FAILURE-ALTDCLEAN2"
+
+            hdisk = find_valid_altdisk(module, action, vios, vios_dict, vios_key, altdisk_op_tab, err_label)
+            if hdisk is None: 
+                break
+            else:
+                OUTPUT.append('    Using {} as alternate disk on {}'.format(vios_dict[vios], vios))
+                logging.info('Using {} as alternate disk on {}'.format(vios_dict[vios], vios))
+
+            if action == 'alt_disk_copy':
+                OUTPUT.append('    Alternate disk copy on {}'.format(vios))
+
+                # alt_disk_copy
+                cmd = "/usr/sbin/nim -o alt_disk_install -a source=rootvg \
+                       -a disk={} -a set_bootlist=no -a boot_client=no {}". \
+                       format(vios_dict[vios], vios)
+                try:
+                    proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    (std_out, std_err) = proc.communicate()
+                except Exception as excep:
+                    msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                            format(cmd, excep.args, std_out, std_err)
+                    module.fail_json(msg=msg)
+                
+                # continue with next target_tuple if alt_disk_copy failed
+                if proc.returncode != 0:
+                    altdisk_op_tab[vios_key] = "{} to copy {} on {}".format(err_label, vios_dict[vios], vios)
+                    OUTPUT.append('    Failed to copy {} on {}: {}'. \
+                            format(vios_dict[vios], vios, std_err))
+                    logging.error('Failed to copy {} on {}: {}'. \
+                            format(vios_dict[vios], vios, std_err))
+                    break
+
+                # wait till alt_disk_install ends
+                res = wait_altdisk_install(module, vios, vios_dict, vios_key, altdisk_op_tab, err_label)
+                if res != 0:
+                    # timed out or an error occured, continue with next target_tuple
+                    break
+
+            elif action == 'alt_disk_clean':
+                OUTPUT.append('    Alternate disk clean on {}'.format(vios))
+
+                # First remove the alternate VG
+                OUTPUT.append('    Remove altinst_rootvg from {} of {}'.format(hdisk, vios))
+                cmd = "/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \
+                        '/usr/sbin/alt_rootvg_op -X altinst_rootvg'". \
+                        format(NIM_NODE['nim_vios'][vios]['vios_ip'])
+                try:
+                    (std_out, std_err) = ("", "")
+                    proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    (std_out, std_err) = proc.communicate()
+                except Exception as excep:
+                    msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                            format(cmd, excep.args, std_out, std_err)
+                    module.fail_json(msg=msg)
+
+                if proc.returncode != 0:
+                    altdisk_op_tab[vios_key] = "{} to remove altinst_rootvg on {}". \
+                        format(err_label, vios)
+                    OUTPUT.append('    Failed to remove altinst_rootvg on {}: {}'. \
+                        format(vios, std_err))
+                    logging.error('Failed to remove altinst_rootvg on {}: {}'. \
+                        format(vios, std_err))
+                    break
+
+                # Clear the hdisk PVID and the LVM info on the disk itself
+                OUTPUT.append('    Clean the PVID and LVM info of {} on {}'.format(hdisk, vios))
+                cmd = "/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \
+                        '/etc/chdev -a pv=clear -l {}; \
+						 /usr/bin/dd if=/dev/zero of=/dev/{}  seek=7 count=1 bs=512'". \
+                        format(NIM_NODE['nim_vios'][vios]['vios_ip'], hdisk, hdisk)
+                try:
+                    (std_out, std_err) = ("", "")
+                    proc = subprocess.Popen(cmd, shell=True, stdin=None, \
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    (std_out, std_err) = proc.communicate()
+                except Exception as excep:
+                    msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                            format(cmd, excep.args, std_out, std_err)
+                    module.fail_json(msg=msg)
+
+                if proc.returncode != 0:
+                    altdisk_op_tab[vios_key] = "{} to clean {} PVID of {} on {}". \
+                        format(err_label, vios_dict[vios], hdisk, vios)
+                    OUTPUT.append('    Failed to clean {} PVID of {} on {}: {}'. \
+                        format(vios_dict[vios], hdisk, vios, std_err))
+                    logging.error('Failed to clean {} PVID of {} on {}: {}'. \
+                        format(vios_dict[vios], hdisk, vios, std_err))
+                    break
+
+    logging.debug('altdisk_op_tab: {}'. format(altdisk_op_tab))
+    return altdisk_op_tab
+
+
+################################################################################
+
+if __name__ == '__main__':
+
+    DEBUG_DATA = []
+    OUTPUT = []
+    PARAMS = {}
+    NIM_NODE = {}
+    CHANGED = False
+    targets_list = []
+    
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            description=dict(required=False, type='str'),
+            targets=dict(required=True, type='str'),
+            action=dict(required=True,
+                        choices=['alt_disk_copy', 'alt_disk_clean'],
+                        type='str'),
+            vios_status=dict(required=False, type='dict'),
+            nim_node=dict(required=False, type='dict'),
+        ),
+        supports_check_mode=True
+    )
+
+    # Open log file
+    logging.basicConfig(filename='/tmp/ansible_vios_alt_disk_debug.log', format= \
+        '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
+        level=logging.DEBUG)
+    logging.debug('*** START VIOS ALT_DISK operation ***')
+
+    # =========================================================================
+    # Get Module params
+    # =========================================================================
+    action = module.params['action']
+    targets = module.params['targets']
+
+    if module.params['description']:
+        description = module.params['description']
+    else:
+        description = "VIOS ALT_DISK - operation: {} request".format(action)
+
+    PARAMS['action'] = action
+    PARAMS['targets'] = targets
+    PARAMS['Description'] = description
+
+    OUTPUT.append('VIOS Alternate disk operation for {}'.format(targets))
+    logging.info('action {} for {} targets'.format(action, targets))
+
+    vios_status = {}
+    targets_altdisk_status = {}
+    target_list = []
+
+    # =========================================================================
+    # build nim node info
+    # =========================================================================
+    if module.params['nim_node']:
+        NIM_NODE = module.params['nim_node']
+    else:
+        build_nim_node(module)
+
+    if module.params['vios_status']:
+        vios_status = module.params['vios_status']
+    else:
+        vios_status = None
+
+    ret = check_vios_targets(targets)
+    if (ret is None) or (not ret):
+        OUTPUT.append('    Warning: Empty target list')
+        logging.warn('Empty target list for targets {}'. \
+                      format(targets))
+
+    else:
+        target_list = ret
+        OUTPUT.append('    Targets list: {}'.format(target_list))
+        logging.debug('Targets list: {}'.format(target_list))
+
+        targets_altdisk_status = alt_disk_action(module, action, target_list,
+                                                 vios_status)
+
+        if targets_altdisk_status:
+            OUTPUT.append('VIOS Alternate disk operation status:')
+            logging.info('VIOS Alternate disk operation status:')
+            for vios_key in targets_altdisk_status.keys():
+                OUTPUT.append("    {} : {}".format(vios_key, targets_altdisk_status[vios_key]))
+                logging.info('    {} : {}'.format(vios_key, targets_altdisk_status[vios_key]))
+        else:
+            OUTPUT.append('VIOS Alternate disk operation: Error getting the status')
+            logging.error('VIOS Alternate disk operation: Error getting the status')
+            targets_altdisk_status = vios_status
+
+    # ==========================================================================
+    # Exit
+    # ==========================================================================
+    module.exit_json(
+        changed=CHANGED,
+        msg="VIOS alt disk operation completed successfully",
+        targets=target_list,
+        nim_node=NIM_NODE,
+        status=targets_altdisk_status,
+        debug_output=DEBUG_DATA,
+        output=OUTPUT)

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -1,0 +1,719 @@
+#!/usr/bin/python
+#
+# Copyright 2017, International Business Machines Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+######################################################################
+
+import os
+import re
+import glob
+import shutil
+import subprocess
+import threading
+import logging
+# Ansible module 'boilerplate'
+from ansible.module_utils.basic import *
+
+
+DOCUMENTATION = """
+---
+module: aix_nim_vios_hc
+author: "Patrice Jacquin"
+version_added: "1.0.0"
+requirements: [ AIX ]
+TBC - change the parsing of the return when vioshc.py is ready
+    - HMC password currently hard-coded
+"""
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def run_oslevel_cmd(machine, result, machine_type):
+    """
+    Run command function, command to be 'threaded'.
+
+    The thread then store the outpout in the dedicated slot of the result
+    dictionnary.
+
+    arguments:
+        machine (str):  The machine name
+        result  (dict): The result of the command
+        machine_type (str): the type of the machine (standalone, vios, master)
+
+    return:
+        the result dictionary entry filled with ethe output of the command
+    """
+
+    if machine_type == 'master':
+        cmd = ['/usr/bin/oslevel', '-s']
+
+    elif machine_type == 'standalone':
+        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
+               '/usr/bin/oslevel -s']
+
+    else: # machine_type == 'vios'
+        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
+               'ioslevel']
+
+    logging.debug('run_oslevel_cmd:{}'.format(cmd))
+
+    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, \
+                         stderr=subprocess.PIPE)
+
+    # return stdout only ... stripped!
+    result[machine] = proc.communicate()[0].rstrip()
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def exec_cmd(cmd, module):
+    """
+    Execute the given command
+        - cmd     array of the command parameters
+        - module  the module variable
+
+    In case of erro set an error massage and fails the module
+
+    return
+        - ret_code  (0)
+        - std_out   output of the command
+    """
+
+    global DEBUG_DATA
+
+    std_out = ''
+    std_err = ''
+    err_code = 0
+
+    logging.debug('exec command:{}'.format(cmd))
+    try:
+        std_out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exc:
+        std_out = exc.output
+        if exc.returncode != 1 and exc.returncode != 2:
+            msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                   format(cmd, exc.cmd, exc.output, exc.returncode)
+            module.fail_json(msg=msg)
+        else:
+            err_code = exc.returncode
+
+    except Exception as exc:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+               format(cmd, exc.args, exc.output, exc.exc.returncode)
+        module.fail_json(msg=msg)
+
+    # DEBUG
+    DEBUG_DATA.append('exec command:{}'.format(cmd))
+    DEBUG_DATA.append('exec command Error:{}'.format(std_err))
+    logging.debug('exec command Error:{}'.format(std_err))
+    logging.debug('exec command output:{}'.format(std_out))
+
+    return (err_code, std_out)
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_hmc_info(module):
+    """
+    Get the hmc info on the nim master, and get their login/passwd
+
+    fill the hmc_dic passed in parameter (filled with the login/passwd value)
+    
+    return a dic with hmc info
+    """
+    std_out = ''
+    std_err = ''
+    info_hash = {}
+
+    cmd = ['lsnim', '-t', 'hmc', '-l']
+
+    try:
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    obj_key = ''
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(\S+):", line)
+        # HMC name
+        if match_key:
+            obj_key = match_key.group(1)
+            info_hash[obj_key] = {}
+            continue
+
+        match_cstate = re.match(r"^\s+Cstate\s+=\s+(.*)$", line)
+        if match_cstate:
+            cstate = match_cstate.group(1)
+            info_hash[obj_key]['cstate'] = cstate
+            continue
+
+        match_key = re.match(r"^\s+passwd_file\s+=\s+(.*)$", line)
+        if match_key:
+            info_hash[obj_key]['passwd_file'] = match_key.group(1)
+            continue
+
+        match_key = re.match(r"^\s+login\s+=\s+(.*)$", line)
+        if match_key:
+            info_hash[obj_key]['login'] = match_key.group(1)
+            continue
+
+        match_key = re.match(r"^\s+if1\s*=\s*\S+\s*(\S*)\s*.*$", line)
+        if match_key:
+            info_hash[obj_key]['ip'] = match_key.group(1)
+            continue
+
+    return info_hash
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_nim_clients_info(module, lpar_type):
+    """
+    Get the list of the lpar (standalones or vios) defined on the nim master, and get their
+    cstate.
+
+    return the list of the name of the lpar objects defined on the
+           nim master and their associated cstate value
+    """
+    std_out = ''
+    std_err = ''
+    info_hash = {}
+
+    cmd = ['lsnim', '-t', lpar_type, '-l']
+
+    try:
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (std_out, std_err) = proc.communicate()
+    except Exception as excep:
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
+                format(cmd, excep.args, std_out, std_err)
+        module.fail_json(msg=msg)
+
+    # lpar name and associated Cstate
+    obj_key = ""
+    for line in std_out.rstrip().split('\n'):
+        match_key = re.match(r"^(\S+):", line)
+        if match_key:
+            obj_key = match_key.group(1)
+            info_hash[obj_key] = {}
+            continue
+
+        match_cstate = re.match(r"^\s+Cstate\s+=\s+(.*)$", line)
+        if match_cstate:
+            cstate = match_cstate.group(1)
+            info_hash[obj_key]['cstate'] = cstate
+            continue
+
+        # For VIOS store the management profile
+        if lpar_type == 'vios':
+            match_mgmtprof = re.match(r"^\s+mgmt_profile1\s+=\s+(.*)$", line)
+            if match_mgmtprof:
+                mgmt_elts = match_mgmtprof.group(1).split()
+                if len(mgmt_elts) == 3:
+                    info_hash[obj_key]['mgmt_hmc_id'] = mgmt_elts[0]
+                    info_hash[obj_key]['mgmt_vios_id'] = mgmt_elts[1]
+                    info_hash[obj_key]['mgmt_cec_serial'] = mgmt_elts[2]
+
+            match_if = re.match(r"^\s+if1\s+=\s+\S+\s+(\S+)\s+.*$", line) 
+            if match_if:
+                info_hash[obj_key]['vios_ip'] = match_if.group(1)
+
+    return info_hash
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def get_nim_vios_oslevel():
+    """
+    Get the oslevel of the vios defined on the nim master.
+
+    return a hash of the vios oslevel
+    """
+
+    # =========================================================================
+    # Launch threads to collect information on targeted nim clients
+    # =========================================================================
+    threads = []
+    vios_oslevel = {}
+
+    for machine in NIM_NODE['nim_vios']:
+        process = threading.Thread(target=run_oslevel_cmd,
+                                   args=(machine, vios_oslevel, 'vios'))
+        process.start()
+        threads.append(process)
+
+    for process in threads:
+        process.join()
+
+    return vios_oslevel
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def build_nim_node(module):
+    """
+    build the nim node containing the nim vios and hmcinfo.
+
+    arguments:
+        None
+
+    return:
+        None
+    """
+
+    global NIM_NODE
+
+    # =========================================================================
+    # Build hmc info list
+    # =========================================================================
+    nim_hmc = {}
+    nim_hmc = get_hmc_info(module)
+
+    NIM_NODE['nim_hmc'] = nim_hmc
+    logging.debug('NIM HMC: {}'.format(nim_hmc))
+
+    # =========================================================================
+    # Build vios info list
+    # =========================================================================
+    nim_vios = {}
+    nim_vios = get_nim_clients_info(module, 'vios')
+
+    NIM_NODE['nim_vios'] = nim_vios
+    logging.debug('NIM VIOS: {}'.format(nim_vios))
+
+    # =========================================================================
+    # get the oslevel of each vios
+    # =========================================================================
+    vios_oslevel = {}
+    vios_oslevel = get_nim_vios_oslevel()
+
+    for (k, val) in vios_oslevel.items():
+        NIM_NODE['nim_vios'][k]['oslevel'] = val
+
+    logging.debug('NIM VIOS: {}'.format(nim_vios))
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def check_vios_targets(targets):
+    """
+    check the list of the vios targets.
+
+    a target name could be of the following form:
+        (vios1, vios2) (vios3)
+
+    arguments:
+        targets (str): list of tuple of NIM name of vios machine
+
+    return: the list of the existing vios tuple matching the target list
+    """
+    global NIM_NODE
+
+    vios_list = {}
+    vios_list_tuples_res = []
+    vios_list_tuples = targets.replace(" ", "").split('(')
+
+    # ===========================================
+    # Build targets list
+    # ===========================================
+    for vios_tuple in vios_list_tuples[1:]:
+
+        logging.debug('Check_vios_targets - vios_tuple: {}'.format(vios_tuple))
+
+        tuple_elts = list(vios_tuple[:-1].split(','))
+        tuple_len = len(tuple_elts)
+
+        if tuple_len != 1 and tuple_len != 2:
+            logging.error('TARGETS: malformed vios targets elt: {} len: {} targets: {}'. \
+                          format(tuple_elts, tuple_len, targets))
+            return None
+
+        # check vios not already exists in the target list
+        if tuple_elts[0] in vios_list or \
+           (tuple_len == 2 and (tuple_elts[1] in vios_list or \
+                                tuple_elts[0] == tuple_elts[1])):
+            logging.error(
+                'TARGETS: malformed vios targets {}. Duplicated values'. \
+                format(targets))
+            return None
+
+        # check vios is knowed by the NIM master - if not ignore it
+        if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
+           (tuple_len == 2 and  tuple_elts[1] not in NIM_NODE['nim_vios']):
+            continue
+
+        if tuple_len == 2:
+            vios_list[tuple_elts[0]] = tuple_elts[1]
+            vios_list[tuple_elts[1]] = tuple_elts[0]
+            # vios_list = vios_list.extend([tuple_elts[0], tuple_elts[1]])
+            my_tuple = (tuple_elts[0], tuple_elts[1])
+            vios_list_tuples_res.append(tuple(my_tuple))
+        else:
+            vios_list[tuple_elts[0]] = tuple_elts[0]
+            # vios_list.append(tuple_elts[0])
+            my_tuple = (tuple_elts[0],)
+            vios_list_tuples_res.append(tuple(my_tuple))
+
+    return vios_list_tuples_res
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def vios_health(module, mgmt_sys_uuid, hmc_login, hmc_passwd, hmc_ip, vios_uuids):
+    """
+    Check the "health" of the given VIOSES
+
+    return: True if ok,
+            False else
+    """
+    global NIM_NODE
+
+    logging.debug('vios_health: hmc_id {} vioses {}'. \
+                  format(hmc_ip, vios_uuids))
+
+    ret = 0
+
+    # build the vioshc cmde
+    cmd = ['/usr/sbin/vioshc.py', '-i', hmc_ip, '-u', hmc_login, \
+           '-p', hmc_passwd, '-m', mgmt_sys_uuid]
+    for vios in vios_uuids:
+        cmd.extend(['-U', vios])
+
+    logging.debug('vios_health: cmd: {}'.format(cmd))
+
+    ret, stdout = exec_cmd(cmd, module)
+    logging.debug('vioshc rc:{} output {}'.format(ret, stdout))
+    if ret != 0:
+        logging.error('vioshc command error rc:{}, output: {}'. \
+                      format(ret, stdout))
+        # TBC
+        # module.fail_json(msg=msg)
+    elif re.search(r'Pass rate of 100%', stdout, re.M):
+        logging.debug('vioses {} can be updated'. \
+                     format(vios_uuids))
+        ret=0
+    else:
+        logging.debug('vioses {} can NOT be updated'. \
+                     format(vios_uuids))
+        ret=1
+
+    return ret
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def vios_health_init(module, hmc_id, hmc_login, hmc_passwd, hmc_ip):
+    """
+    Check the "health" of the given VIOSES for a rolling update point of view
+
+    This operation uses the vioshc.py script to evaluate the capacity of the
+    pair of the VIOSes to support the rolling update operation:
+    - check they manage the same LPARs,
+    - ...
+
+    return: True if ok,
+            False else
+    """
+    global NIM_NODE
+
+    logging.debug('vios_health_init: hmc_id {} hmc_ip {} login {}'. \
+                  format(hmc_id, hmc_ip, hmc_login))
+
+    ret = 0
+    # if needed, call the /usr/sbin/vioshc.py script a first time to
+    # collect UUIDs
+    cmd = ['/usr/sbin/vioshc.py', '-i', hmc_ip, '-u', hmc_login, \
+           '-p', hmc_passwd, '-l', 'a']
+
+    logging.debug('vios_health_init - cmd: {}'.format(cmd))
+
+    ret, stdout = exec_cmd(cmd, module)
+    logging.debug('vioshc rc:{} output {}'.format(ret, stdout))
+    if ret != 0:
+        logging.error('vioshc command error rc:{}, error: {}'. \
+                      format(ret, stdout))
+        msg = 'Health init check failed. vioshc command error. rc:{}, error: {}'. \
+                format(ret, stdout)
+        module.fail_json(msg=msg)
+
+    # Parse the ooutput and store the UUIDs
+    data_start = 0
+    vios_section = 0
+    cec_uuid = ''
+    cec_serial = ''
+    for line in stdout.rstrip().split('\n'):
+        logging.debug('--------line {}'.format(line))
+        if vios_section == 0:
+            # skip the header
+            match_key = re.match(r"^-+\s+-+$", line)
+            if match_key:
+                data_start = 1
+                continue
+            if data_start == 0:
+                continue
+
+            # New managed system section
+            match_key = re.match(r"^(\S+)\s+(\S+)$", line)
+            if match_key:
+                cec_uuid = match_key.group(1)
+                cec_serial = match_key.group(2).replace("*","_")
+                
+                logging.debug('New managed system section:{},{}'.format(cec_uuid, cec_serial))
+                continue
+
+            # New vios section
+            match_key = re.match(r"^\s+-+\s+-+$", line)
+            if match_key:
+                vios_section = 1
+                continue
+
+            # skip all header and empty lines until the vios section
+            continue
+
+        # new vios partition
+        match_key = re.match(r"^\s+(\S+)\s+(\S+)$", line)
+        if match_key:
+            vios_uuid = match_key.group(1)
+            vios_part_id = match_key.group(2)
+            logging.debug('new vios partitionsection:{},{}'.format(vios_uuid,vios_part_id))
+
+            # retrieve the vios with the vios_part_id and the cec_serial value
+            # and store the UUIDs in the dictionaries
+            for vios_key in NIM_NODE['nim_vios']:
+                if NIM_NODE['nim_vios'][vios_key]['mgmt_vios_id'] == vios_part_id \
+                   and \
+                   NIM_NODE['nim_vios'][vios_key]['mgmt_cec_serial'] == cec_serial:
+                    NIM_NODE['nim_vios'][vios_key]['vios_uuid'] = vios_uuid
+                    NIM_NODE['nim_vios'][vios_key]['cec_uuid'] = cec_uuid
+                    break
+            continue
+
+        # skip vios line where lparid is not found.
+        match_key = re.match(r"^\s+(\S+)\s+Not found$", line)
+        if match_key:
+            continue
+
+        # skip empty line after vios section. stop the vios section
+        match_key = re.match(r"^$", line)
+        if match_key:
+            vios_section = 0
+            continue
+
+        logging.error('vioshc command, bad output line:{}'.format(line))
+        msg = 'Health init check failed. Bad vioshc.py command output for the {} hmc - output: {}'. \
+                format(hmc_id, line)
+        module.fail_json(msg=msg)
+
+    logging.debug('vioshc output:{}'.format(line))
+    return ret
+
+
+# ----------------------------------------------------------------
+# ----------------------------------------------------------------
+def health_check(module, targets):
+    """
+    Healt assessment of the VIOSes targets to ensure they can be support
+    a rolling update operation.
+    
+    For each VIOS tuple,
+    - call /usr/sbin/vioshc.py a first time to collect the VIOS UUIDs
+    - call it a second time to check the healthiness
+
+    return: True if ok,
+            False else
+    """
+    global NIM_NODE
+
+    logging.debug('VIOS CHECK - health_check: {}'.format(targets))
+
+    health_tab = {}
+    vios_key = []
+    for target_tuple in targets:
+        logging.debug('VIOS CHECK - health_check target_tuple: {}'.format(target_tuple))
+
+        tup_len = len(target_tuple)
+        vios1 = target_tuple[0]
+        if tup_len == 2:
+            vios2 = target_tuple[1]
+            vios_key = "{}-{}".format(vios1, vios2)
+        else:
+            vios_key = vios1
+        
+        logging.debug('VIOS CHECK - health_check vios1: {}'.format(vios1))
+        cec_serial = NIM_NODE['nim_vios'][vios1]['mgmt_cec_serial']
+        hmc_id = NIM_NODE['nim_vios'][vios1]['mgmt_hmc_id']
+
+        if hmc_id not in NIM_NODE['nim_hmc']:
+            logging.warn("VIOS CHECK - health_check: VIOS {} refers to an inexistant hmc {}". \
+                         format(vios1, hmc_id))
+            health_tab[vios_key] = 'FAILURE-HC'
+            continue
+
+        hmc_login = NIM_NODE['nim_hmc'][hmc_id]['login']
+        hmc_login_len = len(hmc_login)
+        hmc_passfile = NIM_NODE['nim_hmc'][hmc_id]['passwd_file']
+        hmc_ip = NIM_NODE['nim_hmc'][hmc_id]['ip']
+
+        vios_uuid = []
+
+        # TBC - hmc_passwd forced
+        hmc_passwd = 'abc123'
+
+        # if needed call vios_health_init to get the UUIDs value
+        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] or \
+            tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
+
+            ret = vios_health_init(module, hmc_id, hmc_login, hmc_passwd, hmc_ip)
+            if ret != 0:
+                logging.warn("VIOS CHECK - health_check: unable to get UUIDs of {} and {}, ret: {}". \
+                             format(vios1, vios2, ret))
+                health_tab[vios_key] = 'FAILURE-HC'
+                continue
+
+        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] or \
+           tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
+            # vios uuid's not found
+            health_tab[vios_key] = 'FAILURE-HC'
+
+        else:            
+            # run the vios_health check for the vios tuple
+            vios_uuid.append(NIM_NODE['nim_vios'][vios1]['vios_uuid'])
+            if tup_len == 2:
+                vios_uuid.append(NIM_NODE['nim_vios'][vios2]['vios_uuid'])
+
+            mgmt_uuid = NIM_NODE['nim_vios'][vios1]['cec_uuid']
+
+            ret = vios_health(module, mgmt_uuid, hmc_login, hmc_passwd, hmc_ip,
+                              vios_uuid)
+
+            # TBC-Begin - For testing, will be remove !
+            if vios1 == 'gdrh9v1' or vios1 == 'gdrh9v2':
+                ret = 0
+            # TBC-End
+
+            if ret == 0:
+                health_tab[vios_key] = 'SUCCESS-HC'
+            else:
+                health_tab[vios_key] = 'FAILURE-HC'
+
+    logging.debug('VIOS CHECK - health_tab: {}'. format(health_tab))
+    return health_tab
+
+
+################################################################################
+
+if __name__ == '__main__':
+
+    DEBUG_DATA = []
+    OUTPUT = []
+    PARAMS = {}
+    NIM_NODE = {}
+    CHANGED = False
+    targets_list = []
+    
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            description=dict(required=False, type='str'),
+            targets=dict(required=True, type='str'),
+            action=dict(required=True, choices=['health_check'], type='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    # Open log file
+    logging.basicConfig(filename='/tmp/ansible_vios_check_debug.log', format= \
+        '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
+        level=logging.DEBUG)
+    logging.debug('*** START VIOS CHECK operation ***')
+
+    # =========================================================================
+    # Get Module params
+    # =========================================================================
+    action = module.params['action']
+    targets = module.params['targets']
+    if module.params['description']:
+        description = module.params['description']
+    else:
+        description = "VIOS CHECK - operation: {} request".format(action)
+
+    PARAMS['action'] = action
+    PARAMS['targets'] = targets
+    PARAMS['Description'] = description
+
+    OUTPUT.append('VIOS CHECK operation for {}'.format(targets))
+    logging.info('VIOS CHECK - action {} for {} targets'.format(action, targets))
+
+    targets_health_status = {}
+
+    # =========================================================================
+    # build nim node info
+    # =========================================================================
+    build_nim_node(module)
+
+    ret = check_vios_targets(targets)
+    if (ret is None) or (not ret):
+        OUTPUT.append('Empty target list')
+        logging.warn('VIOS CHECK - Warning: Empty target list for targets {}'. \
+                      format(targets))
+
+    else:
+        targets_list = ret
+        OUTPUT.append('Targets list:{}'.format(targets_list))
+        logging.debug('VIOS CHECK - Target list: {}'.format(targets_list))
+
+        # ===============================================
+        # Check vioshc script is present, else install it
+        # ===============================================
+        logging.debug('VIOS CHECK - Check vioshc script ***')
+        vioshcpath = os.path.abspath(os.path.join(os.sep, 'usr', 'sbin'))
+        vioshcfile = os.path.join(vioshcpath, 'vioshc.py')
+
+        if not os.path.exists(vioshcfile):
+            logging.error('VIOS CHECK - Error: cannot find {}'. \
+                                 format(vioshcfile))
+            module.fail_json(msg="VIOS CHECK - Error: cannot find {}". \
+                                 format(vioshcfile))
+
+        st = os.stat(vioshcfile)
+        if not st.st_mode & stat.S_IEXEC:
+            logging.error('VIOS CHECK - Error: bad credentials for {}'. \
+                                 format(vioshcfile))
+            module.fail_json(msg="VIOS CHECK - Error: bad credentials for {}". \
+                                 format(vioshcfile))
+
+        targets_health_status = health_check(module, targets_list)
+        OUTPUT.append('VIOS CHECK Status')
+        for vios_key in targets_health_status.keys():
+            OUTPUT.append("    {} : {}".format(vios_key, targets_health_status[vios_key]))
+
+        logging.info('Health check result: {}'.format(targets_health_status))
+
+    # ==========================================================================
+    # Exit
+    # ==========================================================================
+    module.exit_json(
+        changed=CHANGED,
+        msg="VIOS health check completed successfully",
+        targets=targets_list,
+        nim_node=NIM_NODE,
+        status=targets_health_status,
+        debug_output=DEBUG_DATA,
+        output=OUTPUT)

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -116,9 +116,9 @@ def exec_cmd(cmd, module):
 
     # DEBUG
     DEBUG_DATA.append('exec command:{}'.format(cmd))
-    DEBUG_DATA.append('exec command Error:{}'.format(std_err))
-    logging.debug('exec command Error:{}'.format(std_err))
+    DEBUG_DATA.append('exec command std_err:{}'.format(std_err))
     logging.debug('exec command output:{}'.format(std_out))
+    logging.debug('exec command std_err:{}'.format(std_err))
 
     return (err_code, std_out)
 

--- a/playbook_aix_nim_updateios.yml
+++ b/playbook_aix_nim_updateios.yml
@@ -12,6 +12,7 @@
         accept_licenses: "yes"
         updateios_flags: "-install"
         preview: "no"
+        #time_limit: "mm/dd/yyyy hh:mm"
 
       register: result
 

--- a/playbook_aix_nim_updateios.yml
+++ b/playbook_aix_nim_updateios.yml
@@ -1,16 +1,18 @@
 - name: "NIM ios update on AIX playbook"
   hosts: all
   gather_facts: no
+  vars:
+    log_file: "/tmp/ansible_updateios_debug.log"
 
   tasks:
     - name: "update ios"
       update_ios:
-        targets: "gdrh10v1"
-        filesets: "none"
+        targets: "(gdrh9v1)(gdrh10v1,gdrh10v2)"
+        #filesets: "none"
         installp_bundle: "__smit_bundle_8323538"
         lpp_source: "VIOS_225_30-lpp_source"
         accept_licenses: "yes"
-        updateios_flags: "-install"
+        updateios_flags: "install"
         preview: "no"
         #time_limit: "mm/dd/yyyy hh:mm"
 

--- a/playbook_aix_nim_vios_altdisk.yml
+++ b/playbook_aix_nim_vios_altdisk.yml
@@ -2,6 +2,8 @@
 - name: "VIOS alternate disk copy on AIX"
   hosts: all
   gather_facts: no
+  vars:
+    log_file: "/tmp/ansible_vios_alt_disk_debug.log"
 
   tasks:
     - name: "AIX VIOS ALT DISK COPY"
@@ -9,6 +11,7 @@
         description: 'Perform an alternate disk copy on VIOS'
         targets: "(gdrh9v1,hdisk1,gdrh9v2,hdisk2)"
         action: alt_disk_copy
+        vars: "{{ vars }}"
         #time_limit: "mm/dd/yyyy hh:mm"
 
       register: altdisk_copy_result
@@ -20,6 +23,7 @@
         description: 'Remove the altinst_rootvg from the alternate disk'
         targets: "(gdrh9v1,hdisk1,gdrh9v2,)"
         action: alt_disk_clean
+        vars: "{{ vars }}"
         vios_status: "{{ altdisk_copy_result.status }}"
 
       register: altdisk_result

--- a/playbook_aix_nim_vios_altdisk.yml
+++ b/playbook_aix_nim_vios_altdisk.yml
@@ -9,6 +9,7 @@
         description: 'Perform an alternate disk copy on VIOS'
         targets: "(gdrh9v1,hdisk1,gdrh9v2,hdisk2)"
         action: alt_disk_copy
+        #time_limit: "mm/dd/yyyy hh:mm"
 
       register: altdisk_copy_result
 

--- a/playbook_aix_nim_vios_altdisk.yml
+++ b/playbook_aix_nim_vios_altdisk.yml
@@ -1,0 +1,26 @@
+---
+- name: "VIOS alternate disk copy on AIX"
+  hosts: all
+  gather_facts: no
+
+  tasks:
+    - name: "AIX VIOS ALT DISK COPY"
+      aix_nim_vios_alt_disk:
+        description: 'Perform an alternate disk copy on VIOS'
+        targets: "(gdrh9v1,hdisk1,gdrh9v2,hdisk2)"
+        action: alt_disk_copy
+
+      register: altdisk_copy_result
+
+    - debug: var=altdisk_copy_result
+
+    - name: "AIX VIOS ALT DISK CLEANUP"
+      aix_nim_vios_alt_disk:
+        description: 'Remove the altinst_rootvg from the alternate disk'
+        targets: "(gdrh9v1,hdisk1,gdrh9v2,)"
+        action: alt_disk_clean
+        vios_status: "{{ altdisk_copy_result.status }}"
+
+      register: altdisk_result
+
+    - debug: var=altdisk_result

--- a/playbook_aix_nim_vios_hc.yml
+++ b/playbook_aix_nim_vios_hc.yml
@@ -1,0 +1,17 @@
+---
+- name: "VIOS health check on AIX"
+  hosts: all
+  gather_facts: no
+
+  tasks:
+
+    - name: "AIX HEALTH CHECK"
+      aix_nim_vios_hc:
+        description: 'playbook_aix_vios_health_check'
+        targets: "(gdrh9v1,gdrh9v2) (gdrh10v1,gdrh10v2)"
+        action: health_check
+
+      register: hc_output
+
+    - debug: var=hc_output
+

--- a/playbook_aix_nim_vios_update.yml
+++ b/playbook_aix_nim_vios_update.yml
@@ -2,57 +2,64 @@
 - name: "VIOS update on AIX"
   hosts: all
   gather_facts: no
+  vars:
+    log_file: "/tmp/ansible_vios_update_debug.log"
 
   tasks:
 
     - name: "AIX VIOS HEALTH CHECK"
       aix_nim_vios_hc:
         description: 'Check the VIOS(es) can be updated'
-        targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1) (gdrh9v2)"
+        targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1,gdrh9v2)"
         action: "health_check"
+        vars: "{{ vars }}"
 
       register: hc_result
 
-    - debug: var=hc_result.output
 
     - name: "AIX VIOS ALT DISK COPY"
       aix_nim_vios_alt_disk:
         description: 'Perform the rootvg copy to an alternate disk'
-        targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk1) (gdrh9v2,hdisk1)"
+        targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk1,gdrh9v2,hdisk1)"
         action: "alt_disk_copy"
         vios_status: "{{ hc_result.status }}"
+        vars: "{{ vars }}"
 
       register: altd_result
 
-    - debug: var=altd_result.output
 
     - name: "AIX NIM update ios"
       aix_nim_updateios:
-        targets: "gdrh10v1 gdrh10v2 gdrh9v1 gdrh9v2"
-        filesets: "none"
+        targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1,gdrh9v2)"
+        #filesets: "none"
         installp_bundle: "__smit_bundle_8323538"
         lpp_source: "VIOS_225_30-lpp_source"
         accept_licenses: "yes"
-        updateios_flags: "-install"
+        updateios_flags: "install"
         preview: "no"
+        #time_limit: "mm/dd/yyyy hh:mm"
         vios_status: "{{ altd_result.status }}"
+        vars: "{{ vars }}"
 
       register: updt_result
 
-    - debug: var=updt_result.output
 
     ## Uncommented this section to perfom a cleanup, but be careful
     ## because this would remove the alternate rootvg which is your
     ## backup.
     #- name: "AIX VIOS ALT DISK CLEANUP"
     #- aix_nim_vios_alt_disk:
-    #-   description: 'Remove the altinst_rootvg from the alternate disk'
-    #-   targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) g(gdrh9v2,hdisk4)"
-    #-   action: alt_disk_clean
-    #-   vios_status: "{{ updt_result.status }}"
+    #    description: 'Remove the altinst_rootvg from the alternate disk'
+    #    targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) (gdrh9v2,hdisk4)"
+    #    action: alt_disk_clean
+    #    vios_status: "{{ updt_result.status }}"
+    #    vars: "{{ vars }}"
 
     #- register: altdisk_result
 
+    - debug: var=hc_result.output
+    - debug: var=altd_result.output
+    - debug: var=updt_result.output
     #- debug: var=altdisk_result.output
 
 

--- a/playbook_aix_nim_vios_update.yml
+++ b/playbook_aix_nim_vios_update.yml
@@ -41,15 +41,18 @@
 
     - debug: var=updt_result.output
 
-    - name: "AIX VIOS ALT DISK CLEANUP"
-      aix_nim_vios_alt_disk:
-        description: 'Remove the altinst_rootvg from the alternate disk'
-        targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) g(gdrh9v2,hdisk4)"
-        action: alt_disk_clean
-        vios_status: "{{ updt_result.status }}"
+    ## Uncommented this section to perfom a cleanup, but be careful
+    ## because this would remove the alternate rootvg which is your
+    ## backup.
+    #- name: "AIX VIOS ALT DISK CLEANUP"
+    #- aix_nim_vios_alt_disk:
+    #-   description: 'Remove the altinst_rootvg from the alternate disk'
+    #-   targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) g(gdrh9v2,hdisk4)"
+    #-   action: alt_disk_clean
+    #-   vios_status: "{{ updt_result.status }}"
 
-      register: altdisk_result
+    #- register: altdisk_result
 
-    - debug: var=altdisk_result.output
+    #- debug: var=altdisk_result.output
 
 

--- a/playbook_aix_nim_vios_update.yml
+++ b/playbook_aix_nim_vios_update.yml
@@ -1,0 +1,55 @@
+---
+- name: "VIOS update on AIX"
+  hosts: all
+  gather_facts: no
+
+  tasks:
+
+    - name: "AIX VIOS HEALTH CHECK"
+      aix_nim_vios_hc:
+        description: 'Check the VIOS(es) can be updated'
+        targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1) (gdrh9v2)"
+        action: "health_check"
+
+      register: hc_result
+
+    - debug: var=hc_result.output
+
+    - name: "AIX VIOS ALT DISK COPY"
+      aix_nim_vios_alt_disk:
+        description: 'Perform the rootvg copy to an alternate disk'
+        targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk1) (gdrh9v2,hdisk1)"
+        action: "alt_disk_copy"
+        vios_status: "{{ hc_result.status }}"
+
+      register: altd_result
+
+    - debug: var=altd_result.output
+
+    - name: "AIX NIM update ios"
+      aix_nim_updateios:
+        targets: "gdrh10v1 gdrh10v2 gdrh9v1 gdrh9v2"
+        filesets: "none"
+        installp_bundle: "__smit_bundle_8323538"
+        lpp_source: "VIOS_225_30-lpp_source"
+        accept_licenses: "yes"
+        updateios_flags: "-install"
+        preview: "no"
+        vios_status: "{{ altd_result.status }}"
+
+      register: updt_result
+
+    - debug: var=updt_result.output
+
+    - name: "AIX VIOS ALT DISK CLEANUP"
+      aix_nim_vios_alt_disk:
+        description: 'Remove the altinst_rootvg from the alternate disk'
+        targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) g(gdrh9v2,hdisk4)"
+        action: alt_disk_clean
+        vios_status: "{{ updt_result.status }}"
+
+      register: altdisk_result
+
+    - debug: var=altdisk_result.output
+
+

--- a/playbook_aix_nim_vios_update.yml
+++ b/playbook_aix_nim_vios_update.yml
@@ -7,14 +7,14 @@
 
   tasks:
 
-    - name: "AIX VIOS HEALTH CHECK"
-      aix_nim_vios_hc:
-        description: 'Check the VIOS(es) can be updated'
-        targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1,gdrh9v2)"
-        action: "health_check"
-        vars: "{{ vars }}"
+    #- name: "AIX VIOS HEALTH CHECK"
+    #  aix_nim_vios_hc:
+    #    description: 'Check the VIOS(es) can be updated'
+    #    targets: "(gdrh10v1) (gdrh10v2) (gdrh9v1,gdrh9v2)"
+    #    action: "health_check"
+    #    vars: "{{ vars }}"
 
-      register: hc_result
+    #  register: hc_result
 
 
     - name: "AIX VIOS ALT DISK COPY"
@@ -22,7 +22,7 @@
         description: 'Perform the rootvg copy to an alternate disk'
         targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk1,gdrh9v2,hdisk1)"
         action: "alt_disk_copy"
-        vios_status: "{{ hc_result.status }}"
+        #vios_status: "{{ hc_result.status }}"
         vars: "{{ vars }}"
 
       register: altd_result
@@ -50,14 +50,14 @@
     #- name: "AIX VIOS ALT DISK CLEANUP"
     #- aix_nim_vios_alt_disk:
     #    description: 'Remove the altinst_rootvg from the alternate disk'
-    #    targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk3) (gdrh9v2,hdisk4)"
+    #    targets: "(gdrh10v1,hdisk1) (gdrh10v2,hdisk2) (gdrh9v1,hdisk1) (gdrh9v2,hdisk1)"
     #    action: alt_disk_clean
     #    vios_status: "{{ updt_result.status }}"
     #    vars: "{{ vars }}"
 
     #- register: altdisk_result
 
-    - debug: var=hc_result.output
+    #- debug: var=hc_result.output
     - debug: var=altd_result.output
     - debug: var=updt_result.output
     #- debug: var=altdisk_result.output


### PR DESCRIPTION
Add Altdisk copy and Health Check, add time_limit and playbook global variable (to set common log file) support.
Fix various issues and traces.
Comment the cleanup operation by default
Improve the alternate disk choice:
- check the disks PVID to ensure they are not the same disk shared on both VIOSes,  
- use USED PPs and TOTAL PPs to chack the size of the rootvg and choose a disk with a similar size if not specified
- allow to take a smaller disk than the current one if it can contain the rootvg
