### PR TITLE
Add SSP support and fix Travis complaints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,27 @@ python:
 # command to install dependencies
 install:
   - pip install ansible
-  - pip install pylint
+  #- pip install pylint
   - pip install flake8
+  - pip install pycodestyle
   - ansible --version
 
 # command to run tests
 script:
-  # ignore "Use % formatting in logging functions" for now in Lint
-  - pylint library/* -d W1202 
-  - flake8 library/* --max-line-length=100   # same line lenght as Lint
+  # With pylint ignore
+  #   logging-format-interpolation: Use % formatting in logging functions
+  #   global-statement : Using the global statement
+  #- pylint library/* -d logging-format-interpolation -d global-statement 
+
+  # With flake ignore
+  #  F403: <module> import *' used; unable to detect undefined names
+  #  F405: <var> may be undefined, or defined from star imports
+  #  W503: line break before binary operator (PEP8 advices to put logical operator ahead)
+  - flake8 library/* --max-line-length=100 --ignore F403,F405,W503
+
+  # pycodestyle (PEP8)
+  - pycodestyle library/* --max-line-length=100
+
   # checking yaml syntax is not relevant since there are just examples.
   #- ansible-playbook playbook_aix_flrtvc.yml --syntax-check
   #- ansible-playbook playbook_aix_suma_targets_all.yml --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ install:
 
 # command to run tests
 script:
-  - pylint library/*
-  - flake8 library/*
+  # ignore "Use % formatting in logging functions" for now in Lint
+  - pylint library/* -d W1202 
+  - flake8 library/* --max-line-length=100   # same line lenght as Lint
   # checking yaml syntax is not relevant since there are just examples.
   #- ansible-playbook playbook_aix_flrtvc.yml --syntax-check
   #- ansible-playbook playbook_aix_suma_targets_all.yml --syntax-check

--- a/library/aix_flrtvc.py
+++ b/library/aix_flrtvc.py
@@ -695,10 +695,10 @@ if __name__ == '__main__':
 
     TARGETS = expand_targets(re.split(r'[,\s]', MODULE.params['targets']), NIM_CLIENTS)
     FLRTVC_PARAMS = {'apar_type': MODULE.params['apar'],
-                     'apar_csv':  MODULE.params['csv'],
-                     'filesets':  MODULE.params['filesets'],
-                     'dst_path':  MODULE.params['path'],
-                     'verbose':   MODULE.params['verbose']}
+                     'apar_csv': MODULE.params['csv'],
+                     'filesets': MODULE.params['filesets'],
+                     'dst_path': MODULE.params['path'],
+                     'verbose': MODULE.params['verbose']}
     FORCE = MODULE.params['force']
     # TBC - Temporary - invalidate the force option
     FORCE = False

--- a/library/aix_nim.py
+++ b/library/aix_nim.py
@@ -121,7 +121,6 @@ def get_nim_clients_info(module, lpar_type):
     std_err = ''
     info_hash = {}
 
-
     cmd = ['lsnim', '-t', lpar_type, '-l']
 
     try:
@@ -927,25 +926,25 @@ def nim_maintenance(module):
     global NIM_CHANGED
     global NIM_NODE
 
-    logging.info('NIM - {} maintenance operation on {}'.\
-                 format(NIM_PARAMS['operation'], NIM_PARAMS['targets']))
+    logging.info('NIM - {} maintenance operation on {}'
+                 .format(NIM_PARAMS['operation'], NIM_PARAMS['targets']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
     logging.debug('NIM - Target list: {}'.format(target_list))
 
-    flag = '-c' # initialized to commit flag
+    flag = '-c'  # initialized to commit flag
 
     retcode = 0
-    cmde =''
+    cmde = ''
     for target in target_list:
-        logging.info('NIM - perform smaintenance operation for client(s) {}'. \
-                      format(target))
+        logging.info('NIM - perform smaintenance operation for client(s) {}'
+                     .format(target))
         if target in NIM_NODE['standalone']:
-            cmde = '/usr/sbin/nim -o maint -a installp_flags={} -a filesets=ALL {}'. \
-                    format(flag, target)
+            cmde = '/usr/sbin/nim -o maint -a installp_flags={} -a filesets=ALL {}'\
+                   .format(flag, target)
         else:
-            cmde = cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
-                   target, '"/usr/sbin/installp -c all"']
+            cmde = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', target,
+                    '"/usr/sbin/installp -c all"']
 
         logging.debug('NIM - Command:{}'.format(cmde))
         NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -959,10 +958,10 @@ def nim_maintenance(module):
 
         NIM_OUTPUT.append('NIM - Finish Commiting {}.'.format(target))
         if ret != 0:
-            logging.error("Error: NIM Command: {} failed with return code {}". \
-                          format(cmde, ret))
-            NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'. \
-                          format(cmde))
+            logging.error("Error: NIM Command: {} failed with return code {}"
+                          .format(cmde, ret))
+            NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'
+                              .format(cmde))
             retcode = 1
         else:
             logging.info("nim maintenance operation: {} done".format(cmde))

--- a/library/aix_nim.py
+++ b/library/aix_nim.py
@@ -86,12 +86,12 @@ def exec_cmd(cmd, module):
     try:
         std_out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
-        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
-               format(cmd, exc.cmd, exc.output, exc.returncode)
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'\
+              .format(cmd, exc.cmd, exc.output, exc.returncode)
         module.fail_json(msg=msg)
     except Exception as exc:
-        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
-               format(cmd, exc.args, std_out, std_err)
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'\
+              .format(cmd, exc.args, std_out, std_err)
         module.fail_json(msg=msg)
 
     #########################################################
@@ -127,8 +127,8 @@ def get_nim_clients_info(module):
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
-        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
-                format(cmd, excep.args, std_out, std_err)
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'\
+              .format(cmd, excep.args, std_out, std_err)
         module.fail_json(msg=msg)
 
     # client name and associated Cstate
@@ -163,8 +163,8 @@ def get_nim_master_info(module):
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
-        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
-                format(cmd, excep.args, std_out, std_err)
+        msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'\
+              .format(cmd, excep.args, std_out, std_err)
         module.fail_json(msg=msg)
 
     # client name and associated Cstate
@@ -446,28 +446,28 @@ def print_node_by_columns():
     widths['cstate'] += 2
 
     # build the array
-    sep = '\n' + '+' + '-' * widths['machine'] + '+' + \
-          '-' * widths['oslevel'] + '+' + '-' * widths['cstate'] + '+'
+    sep = '\n' + '+' + '-' * widths['machine'] + '+' \
+          + '-' * widths['oslevel'] + '+' + '-' * widths['cstate'] + '+'
 
-    head = '\n' + \
-           '|' + '{:^{wid}}'.format('machine', wid=widths['machine']) + \
-           '|' + '{:^{wid}}'.format('oslevel', wid=widths['oslevel']) + \
-           '|' + '{:^{wid}}'.format('Cstate', wid=widths['cstate']) + '|'
+    head = '\n' \
+           + '|' + '{:^{wid}}'.format('machine', wid=widths['machine']) \
+           + '|' + '{:^{wid}}'.format('oslevel', wid=widths['oslevel']) \
+           + '|' + '{:^{wid}}'.format('Cstate', wid=widths['cstate']) + '|'
 
     result = sep + head + sep
 
     for (k, val) in NIM_NODE['nim_clients'].items():
-        line = '\n' + \
-               '|' + '{0:^{1}}'.format(k, widths['machine']) + \
-               '|' + '{0:^{1}}'.format(val['oslevel'], widths['oslevel']) + \
-               '|' + '{0:^{1}}'.format(val['cstate'], widths['cstate']) + '|'
+        line = '\n' \
+               + '|' + '{0:^{1}}'.format(k, widths['machine']) \
+               + '|' + '{0:^{1}}'.format(val['oslevel'], widths['oslevel']) \
+               + '|' + '{0:^{1}}'.format(val['cstate'], widths['cstate']) + '|'
         result += line
 
     # master
-    line = '\n' + \
-           '|' + '{0:^{1}}'.format('master', widths['machine']) + \
-           '|' + '{0:^{1}}'.format(NIM_NODE['master']['oslevel'], widths['oslevel']) + \
-           '|' + '{0:^{1}}'.format(NIM_NODE['master']['cstate'], widths['cstate']) + '|'
+    line = '\n' \
+           + '|' + '{0:^{1}}'.format('master', widths['machine']) \
+           + '|' + '{0:^{1}}'.format(NIM_NODE['master']['oslevel'], widths['oslevel']) \
+           + '|' + '{0:^{1}}'.format(NIM_NODE['master']['cstate'], widths['cstate']) + '|'
     result += line
 
     result += sep
@@ -703,8 +703,9 @@ def find_resource_by_client(lpp_type, lpp_time, oslevel_elts):
         # reading lpp_source table until we have found the good sp
         for lpp in lpp_source_list:
             lpp_elts = lpp.split('-')
-            if lpp_elts[0] != oslevel_elts[0] or \
-               lpp_elts[1] != oslevel_elts[1] or lpp_elts[2] <= oslevel_elts[2]:
+            if lpp_elts[0] != oslevel_elts[0] \
+               or lpp_elts[1] != oslevel_elts[1] \
+               or lpp_elts[2] <= oslevel_elts[2]:
                 continue
             lpp_source = lpp
             if lpp_time == 'next':
@@ -749,9 +750,10 @@ def nim_update(module):
     logging.info('NIM - {} update operation on {} with {} lpp_source'
                  .format(log_async, NIM_PARAMS['targets'], lpp_source))
 
-    if NIM_PARAMS['async'] == 'true' and \
-       (lpp_source == 'latest_tl' or lpp_source == 'latest_sp' or
-        lpp_source == 'next_tl' or lpp_source == 'next_sp'):
+    if NIM_PARAMS['async'] == 'true' and (lpp_source == 'latest_tl'
+                                          or lpp_source == 'latest_sp'
+                                          or lpp_source == 'next_tl'
+                                          or lpp_source == 'next_sp'):
         logging.warning('Force customization synchronously')
         async_update = 'no'
 
@@ -796,8 +798,8 @@ def nim_update(module):
 
             # get lpp source
             new_lpp_source = ''
-            if (lpp_source == 'latest_tl') or (lpp_source == 'latest_sp') or \
-               (lpp_source == 'next_tl') or (lpp_source == 'next_sp'):
+            if lpp_source == 'latest_tl' or lpp_source == 'latest_sp' \
+               or lpp_source == 'next_tl' or lpp_source == 'next_sp':
                 lpp_source_array = lpp_source.split('_')
                 lpp_time = lpp_source_array[0]
                 lpp_type = lpp_source_array[1]
@@ -828,9 +830,9 @@ def nim_update(module):
                 logging.warning('Machine {} has different release than {}'
                                 .format(target, oslevel_elts[0]))
                 continue
-            elif cur_oslevel_elts[1] > oslevel_elts[1] or \
-                 cur_oslevel_elts[1] == oslevel_elts[1] and \
-                 cur_oslevel_elts[2] >= oslevel_elts[2]:
+            elif (cur_oslevel_elts[1] > oslevel_elts[1]
+                  or cur_oslevel_elts[1] == oslevel_elts[1]
+                  and cur_oslevel_elts[2] >= oslevel_elts[2]):
                 logging.warning('Machine {} is already at same or higher level than {}'
                                 .format(target, '-'.join(oslevel_elts)))
                 continue
@@ -939,8 +941,8 @@ def nim_compare(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_OUTPUT.append('compare installation inventory:')
     NIM_OUTPUT.append(stdout.split('\n'))
@@ -991,8 +993,8 @@ def nim_script(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1033,8 +1035,8 @@ def nim_allocate(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1075,8 +1077,8 @@ def nim_deallocate(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1125,8 +1127,8 @@ def nim_bos_inst(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1165,8 +1167,8 @@ def nim_define_script(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1204,8 +1206,8 @@ def nim_remove(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1268,8 +1270,8 @@ def nim_reset(module):
             logging.error("Error: NIM Command: {} failed with return code {}"
                           .format(cmde, ret))
             module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+                msg="NIM Command: {} failed with return code {} => Error :{}"
+                .format(cmde, ret, stderr.split('\n')))
 
         NIM_CHANGED = True
 
@@ -1313,8 +1315,8 @@ def nim_reboot(module):
         logging.error("Error: NIM Command: {} failed with return code {}"
                       .format(cmde, ret))
         module.fail_json(
-               msg="NIM Command: {} failed with return code {} => Error :{}"
-               .format(cmde, ret, stderr.split('\n')))
+            msg="NIM Command: {} failed with return code {} => Error :{}"
+            .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret

--- a/library/aix_nim.py
+++ b/library/aix_nim.py
@@ -56,8 +56,8 @@ def run_oslevel_cmd(machine, result):
         cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
                '/usr/bin/oslevel -s']
 
-    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, \
-                         stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
 
     # return stdout only ... stripped!
     result[machine] = proc.communicate()[0].rstrip()
@@ -123,8 +123,8 @@ def get_nim_clients_info(module):
     cmd = ['lsnim', '-t', 'standalone', '-l']
 
     try:
-        proc = subprocess.Popen(cmd, shell=False, stdin=None, \
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
         msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
@@ -159,8 +159,8 @@ def get_nim_master_info(module):
     cmd = ['lsnim', '-l', 'master']
 
     try:
-        proc = subprocess.Popen(cmd, shell=False, stdin=None, \
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
         msg = 'Command: {} Exception.Args{} =>Data:{} ... Error :{}'. \
@@ -278,12 +278,10 @@ def build_nim_node(module):
     nim_lpp_sources = {}
     ret, nim_lpp_sources = get_nim_lpp_source(module)
     if ret != 0:
-        logging.error( \
-               'NIM - Error getting the lpp_source list - rc:{}, error:{}'. \
-               format(ret, nim_lpp_sources))
-        module.fail_json( \
-               msg="NIM Error getting th lpp_source list - rc:{}, error:{}". \
-               format(ret, nim_lpp_sources))
+        logging.error('NIM - Error getting the lpp_source list - rc:{}, error:{}'
+                      .format(ret, nim_lpp_sources))
+        module.fail_json(msg="NIM Error getting th lpp_source list - rc:{}, error:{}"
+                         .format(ret, nim_lpp_sources))
 
     NIM_NODE['lpp_source'] = nim_lpp_sources
     logging.debug('lpp source list: {}'.format(nim_lpp_sources))
@@ -449,27 +447,27 @@ def print_node_by_columns():
 
     # build the array
     sep = '\n' + '+' + '-' * widths['machine'] + '+' + \
-                 '-' * widths['oslevel'] + '+' + '-' * widths['cstate']  + '+'
+          '-' * widths['oslevel'] + '+' + '-' * widths['cstate'] + '+'
 
     head = '\n' + \
-            '|' + '{:^{wid}}'.format('machine', wid=widths['machine']) + \
-            '|' + '{:^{wid}}'.format('oslevel', wid=widths['oslevel']) + \
-            '|' + '{:^{wid}}'.format('Cstate', wid=widths['cstate']) + '|'
+           '|' + '{:^{wid}}'.format('machine', wid=widths['machine']) + \
+           '|' + '{:^{wid}}'.format('oslevel', wid=widths['oslevel']) + \
+           '|' + '{:^{wid}}'.format('Cstate', wid=widths['cstate']) + '|'
 
     result = sep + head + sep
 
     for (k, val) in NIM_NODE['nim_clients'].items():
         line = '\n' + \
-                '|' + '{0:^{1}}'.format(k, widths['machine']) + \
-                '|' + '{0:^{1}}'.format(val['oslevel'], widths['oslevel']) + \
-                '|' + '{0:^{1}}'.format(val['cstate'], widths['cstate']) + '|'
+               '|' + '{0:^{1}}'.format(k, widths['machine']) + \
+               '|' + '{0:^{1}}'.format(val['oslevel'], widths['oslevel']) + \
+               '|' + '{0:^{1}}'.format(val['cstate'], widths['cstate']) + '|'
         result += line
 
     # master
     line = '\n' + \
-                '|' + '{0:^{1}}'.format('master', widths['machine']) + \
-                '|' + '{0:^{1}}'.format(NIM_NODE['master']['oslevel'], widths['oslevel']) + \
-                '|' + '{0:^{1}}'.format(NIM_NODE['master']['cstate'], widths['cstate']) + '|'
+           '|' + '{0:^{1}}'.format('master', widths['machine']) + \
+           '|' + '{0:^{1}}'.format(NIM_NODE['master']['oslevel'], widths['oslevel']) + \
+           '|' + '{0:^{1}}'.format(NIM_NODE['master']['cstate'], widths['cstate']) + '|'
     result += line
 
     result += sep
@@ -491,17 +489,16 @@ def perform_async_customization(module, lpp_source, targets):
 
     global NIM_OUTPUT
 
-    logging.debug( \
-          'NIM - perform_async_customization - lpp_spource: {}, targets: {} '.\
-          format(lpp_source, targets))
+    logging.debug('NIM - perform_async_customization - lpp_spource: {}, targets: {} '
+                  .format(lpp_source, targets))
 
     cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all '\
            '-a accept_licenses=yes -a async=yes {}'.format(lpp_source, targets)
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
-    NIM_OUTPUT.append('Start updating machine(s) {} to {}'. \
-                       format(targets, lpp_source))
+    NIM_OUTPUT.append('Start updating machine(s) {} to {}'
+                      .format(targets, lpp_source))
 
     do_not_error = False
 
@@ -519,13 +516,13 @@ def perform_async_customization(module, lpp_source, targets):
         if matched:
             do_not_error = True
 
-    NIM_OUTPUT.append('NIM - Finish updating {} asynchronously.'. \
-                      format(targets))
+    NIM_OUTPUT.append('NIM - Finish updating {} asynchronously.'
+                      .format(targets))
     if ret != 0 or do_not_error:
-        logging.error("Error: NIM Command: {} failed with return code {}". \
-                      format(cmde, ret))
-        NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'. \
-                      format(cmde))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'
+                          .format(cmde))
 
     logging.info("Done nim customize operation {}".format(cmde))
 
@@ -547,16 +544,16 @@ def perform_sync_customization(module, lpp_source, targets):
     global NIM_OUTPUT
 
     logging.debug(
-        'NIM - perform_sync_customization - lpp_spource: {}, targets: {} '.\
-                                                  format(lpp_source, targets))
+        'NIM - perform_sync_customization - lpp_spource: {}, targets: {} '
+        .format(lpp_source, targets))
 
     cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all '\
            '-a accept_licenses=yes -a async=no {}'.format(lpp_source, targets)
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
-    NIM_OUTPUT.append('Start updating machine(s) {} to {}'. \
-                       format(targets, lpp_source))
+    NIM_OUTPUT.append('Start updating machine(s) {} to {}'
+                      .format(targets, lpp_source))
 
     do_not_error = False
 
@@ -587,10 +584,10 @@ def perform_sync_customization(module, lpp_source, targets):
 
     NIM_OUTPUT.append('NIM - Finish updating {} synchronously.'.format(targets))
     if ret != 0 or do_not_error:
-        logging.error("Error: NIM Command: {} failed with return code {}". \
-                      format(cmde, ret))
-        NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'. \
-                      format(cmde))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        NIM_OUTPUT.append('NIM - Error: Command {} returns above error!'
+                          .format(cmde))
 
     logging.info("Done nim customize operation {}".format(cmde))
 
@@ -613,8 +610,8 @@ def list_fixes(target, module):
     if target == 'master':
         cmde = '/usr/sbin/emgr -l'
     else:
-        cmde = '/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \"/usr/sbin/emgr -l\"'. \
-                                                format(target)
+        cmde = '/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \"/usr/sbin/emgr -l\"'\
+               .format(target)
     logging.debug('EMGR list - Command:{}'.format(cmde))
 
     ret, stdout, stderr = module.run_command(cmde)
@@ -627,18 +624,17 @@ def list_fixes(target, module):
         line_array = line.split(' ')
         matched = re.match(r"[0-9]", line_array[0])
         if matched:
-            logging.debug('EMGR list - adding fix {} to fixes list'. \
-                           format(line_array[2]))
+            logging.debug('EMGR list - adding fix {} to fixes list'
+                          .format(line_array[2]))
             fixes.append(line_array[2])
 
     NIM_OUTPUT.append('{}'.format(stderr))
 
     if ret != 0:
-        logging.error("Error: Command: {} failed with return code {}". \
-                      format(cmde, ret))
-        NIM_OUTPUT.append( \
-                      'EMGR list - Error: Command {} returns above error!'. \
-                      format(cmde))
+        logging.error("Error: Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        NIM_OUTPUT.append('EMGR list - Error: Command {} returns above error!'
+                          .format(cmde))
 
     return(ret, fixes)
 
@@ -657,8 +653,8 @@ def remove_fix(target, fix, module):
     if target == 'master':
         cmde = '/usr/sbin/emgr -r -L {}'.format(fix)
     else:
-        cmde = '/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \"/usr/sbin/emgr -r -L {}\"'. \
-           format(target, fix)
+        cmde = '/usr/lpp/bos.sysmgt/nim/methods/c_rsh {} \"/usr/sbin/emgr -r -L {}\"'\
+               .format(target, fix)
     logging.debug('EMGR remove - Command:{}'.format(cmde))
 
     ret, stdout, stderr = module.run_command(cmde)
@@ -668,10 +664,10 @@ def remove_fix(target, fix, module):
     NIM_OUTPUT.append('{}'.format(stderr))
 
     if ret != 0:
-        logging.error("Error: Command: {} failed with return code {}". \
-                      format(cmde, ret))
-        NIM_OUTPUT.append('EMGR remove - Error: Command {} returns above error!'. \
-                      format(cmde))
+        logging.error("Error: Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        NIM_OUTPUT.append('EMGR remove - Error: Command {} returns above error!'
+                          .format(cmde))
 
     return ret
 
@@ -716,14 +712,13 @@ def find_resource_by_client(lpp_type, lpp_time, oslevel_elts):
 
     if (lpp_source is None) or (not lpp_source.strip()):
         # setting lpp_source to current oslevel if not found
-        lpp_source = '{}-{}-{}-{}-lpp_source'. \
-                     format(oslevel_elts[0], oslevel_elts[1], \
-                            oslevel_elts[2], oslevel_elts[3])
-        logging.debug('NIM - find resource: server already to the {} {}, or no lpp_source were '\
+        lpp_source = '{}-{}-{}-{}-lpp_source'.format(oslevel_elts[0], oslevel_elts[1],
+                                                     oslevel_elts[2], oslevel_elts[3])
+        logging.debug('NIM - find resource: server already to the {} {}, or no lpp_source were '
                       'found, {} will be utilized'.format(lpp_time, lpp_type, lpp_source))
     else:
-        logging.debug('NIM - find resource: found the {} lpp_source, {} will be utilized'. \
-                       format(lpp_time, lpp_source))
+        logging.debug('NIM - find resource: found the {} lpp_source, {} will be utilized'
+                      .format(lpp_time, lpp_source))
 
     return lpp_source
 
@@ -751,13 +746,12 @@ def nim_update(module):
     else:
         log_async = 'synchronous'
 
-    logging.info('NIM - {} update operation on {} with {} lpp_source'.\
-                 format(log_async, NIM_PARAMS['targets'], \
-                                   lpp_source))
+    logging.info('NIM - {} update operation on {} with {} lpp_source'
+                 .format(log_async, NIM_PARAMS['targets'], lpp_source))
 
     if NIM_PARAMS['async'] == 'true' and \
-              (lpp_source == 'latest_tl' or lpp_source == 'latest_sp' or \
-              lpp_source == 'next_tl' or lpp_source == 'next_sp'):
+       (lpp_source == 'latest_tl' or lpp_source == 'latest_sp' or
+        lpp_source == 'next_tl' or lpp_source == 'next_sp'):
         logging.warning('Force customization synchronously')
         async_update = 'no'
 
@@ -769,21 +763,20 @@ def nim_update(module):
         for target in target_list:
             (ret, fixes) = list_fixes(target, module)
             if ret != 0:
-                logging.info("Continue to remove as many interim fixes we can".format(cmde, ret))
+                logging.info("Continue to remove as many interim fixes we can")
             for fix in fixes:
                 remove_fix(target, fix, module)
-                logging.warning( \
-                     "Interim fix {} has been automatically removed from {}". \
-                     format(fix, target))
+                logging.warning("Interim fix {} has been automatically removed from {}"
+                                .format(fix, target))
 
     if async_update == 'yes':   # async update
         if lpp_source not in NIM_NODE['lpp_source']:
-            logging.error('NIM - Error: cannot find lpp_source {}'. \
-                                              format(lpp_source))
-            module.fail_json(msg="NIM - Error: cannot find lpp_source {}". \
-                                              format(NIM_NODE['lpp_sources']))
+            logging.error('NIM - Error: cannot find lpp_source {}'
+                          .format(lpp_source))
+            module.fail_json(msg="NIM - Error: cannot find lpp_source {}"
+                             .format(NIM_NODE['lpp_sources']))
         else:
-            logging.info('NIM - perform asynchronous software customization for client(s) {} '\
+            logging.info('NIM - perform asynchronous software customization for client(s) {} '
                          'with resource {}'.format(' '.join(target_list), lpp_source))
             perform_async_customization(module, lpp_source, ' '.join(target_list))
 
@@ -797,56 +790,55 @@ def nim_update(module):
                 cur_oslevel = NIM_NODE['nim_clients'][target]['oslevel']
             logging.debug('NIM - current oslevel: {}'.format(cur_oslevel))
             if (cur_oslevel is None) or (not cur_oslevel.strip()):
-                logging.warning('Cannot get oslevel for machine {}'. \
-                                format(target))
+                logging.warning('Cannot get oslevel for machine {}'.format(target))
                 continue
             cur_oslevel_elts = cur_oslevel.split('-')
 
             # get lpp source
             new_lpp_source = ''
             if (lpp_source == 'latest_tl') or (lpp_source == 'latest_sp') or \
-                         (lpp_source == 'next_tl') or (lpp_source == 'next_sp'):
+               (lpp_source == 'next_tl') or (lpp_source == 'next_sp'):
                 lpp_source_array = lpp_source.split('_')
                 lpp_time = lpp_source_array[0]
                 lpp_type = lpp_source_array[1]
-                new_lpp_source = find_resource_by_client(lpp_type, lpp_time, \
+                new_lpp_source = find_resource_by_client(lpp_type, lpp_time,
                                                          cur_oslevel_elts)
                 logging.debug('NIM - new_lpp_source: {}'.format(new_lpp_source))
             else:
                 if lpp_source not in NIM_NODE['lpp_source']:
-                    logging.error('NIM - Error: cannot find lpp_source {}'. \
-                                              format(lpp_source))
-                    module.fail_json(msg="NIM - Error: cannot find lpp_source {}". \
-                                              format(NIM_NODE['lpp_source']))
+                    logging.error('NIM - Error: cannot find lpp_source {}'
+                                  .format(lpp_source))
+                    module.fail_json(msg="NIM - Error: cannot find lpp_source {}"
+                                     .format(NIM_NODE['lpp_source']))
                 else:
                     new_lpp_source = lpp_source
 
             # extract oslevel from lpp source
             oslevel_elts = []
-            matched = re.match(r"^([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})-lpp_source$", \
+            matched = re.match(r"^([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})-lpp_source$",
                                new_lpp_source)
             if matched:
                 oslevel_elts = matched.group(1).split('-')
             else:
-                logging.warning('Cannot get oslevel from lpp source name {}'. \
-                                format(new_lpp_source))
+                logging.warning('Cannot get oslevel from lpp source name {}'
+                                .format(new_lpp_source))
                 continue
 
             if cur_oslevel_elts[0] != oslevel_elts[0]:
-                logging.warning('Machine {} has different release than {}'. \
-                                format(target, oslevel_elts[0]))
+                logging.warning('Machine {} has different release than {}'
+                                .format(target, oslevel_elts[0]))
                 continue
             elif cur_oslevel_elts[1] > oslevel_elts[1] or \
                  cur_oslevel_elts[1] == oslevel_elts[1] and \
                  cur_oslevel_elts[2] >= oslevel_elts[2]:
-                logging.warning('Machine {} is already at same or higher level than {}'. \
-                                format(target, '-'.join(oslevel_elts)))
+                logging.warning('Machine {} is already at same or higher level than {}'
+                                .format(target, '-'.join(oslevel_elts)))
                 continue
             else:
-                logging.info('Machine {} needs upgrade from {} to {}'. \
-                                format(target, cur_oslevel, '-'.join(oslevel_elts)))
+                logging.info('Machine {} needs upgrade from {} to {}'
+                             .format(target, cur_oslevel, '-'.join(oslevel_elts)))
 
-            logging.info('NIM - perform synchronous software customization for client(s) {} '\
+            logging.info('NIM - perform synchronous software customization for client(s) {} '
                          'with resource {}'.format(target, new_lpp_source))
             perform_sync_customization(module, new_lpp_source, target)
 
@@ -868,11 +860,11 @@ def nim_master_setup(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info('NIM - master setup operation using {} device'.\
-                                                format(NIM_PARAMS['device']))
+    logging.info('NIM - master setup operation using {} device'
+                 .format(NIM_PARAMS['device']))
 
-    cmde = 'nim_master_setup -B -a mk_resource=no -a device={}'. \
-                                                format(NIM_PARAMS['device'])
+    cmde = 'nim_master_setup -B -a mk_resource=no -a device={}'\
+           .format(NIM_PARAMS['device'])
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -884,11 +876,10 @@ def nim_master_setup(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(msg="NIM Command: {} failed with return code {} => Error :{}"
+                         .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -925,15 +916,15 @@ def nim_compare(module):
     """
     global NIM_OUTPUT
 
-    logging.info('NIM - installation inventory comparison for {} clients'.\
-                format(NIM_PARAMS['targets']))
+    logging.info('NIM - installation inventory comparison for {} clients'
+                 .format(NIM_PARAMS['targets']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
 
     logging.debug('NIM - Target list: {}'.format(target_list))
 
-    cmde = 'niminv -o invcmp -a targets={} -a base=any'. \
-                                                  format(','.join(target_list))
+    cmde = 'niminv -o invcmp -a targets={} -a base=any'\
+           .format(','.join(target_list))
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -945,11 +936,11 @@ def nim_compare(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_OUTPUT.append('compare installation inventory:')
     NIM_OUTPUT.append(stdout.split('\n'))
@@ -977,15 +968,15 @@ def nim_script(module):
         async_script = 'no'
         log_async = 'synchronous'
 
-    logging.info('NIM - {} customize operation on {} with {} script'.\
-                format(log_async, NIM_PARAMS['targets'], NIM_PARAMS['script']))
+    logging.info('NIM - {} customize operation on {} with {} script'
+                 .format(log_async, NIM_PARAMS['targets'], NIM_PARAMS['script']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
 
     logging.debug('NIM - Target list: {}'.format(target_list))
 
-    cmde = 'nim -o cust -a script={} -a async={} {}'. \
-           format(NIM_PARAMS['script'], async_script, ' '.join(target_list))
+    cmde = 'nim -o cust -a script={} -a async={} {}'\
+           .format(NIM_PARAMS['script'], async_script, ' '.join(target_list))
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -997,11 +988,11 @@ def nim_script(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1019,15 +1010,15 @@ def nim_allocate(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info('NIM - alloacte operation on {} for {} lpp source'.\
-                      format(NIM_PARAMS['targets'], NIM_PARAMS['lpp_source']))
+    logging.info('NIM - alloacte operation on {} for {} lpp source'
+                 .format(NIM_PARAMS['targets'], NIM_PARAMS['lpp_source']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
 
     logging.debug('NIM - Target list: {}'.format(target_list))
 
-    cmde = 'nim -o allocate -a lpp_source={} {}'. \
-                     format(NIM_PARAMS['lpp_source'], ' '.join(target_list))
+    cmde = 'nim -o allocate -a lpp_source={} {}'\
+           .format(NIM_PARAMS['lpp_source'], ' '.join(target_list))
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -1039,11 +1030,11 @@ def nim_allocate(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1061,15 +1052,15 @@ def nim_deallocate(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info('NIM - dealloacte operation on {} for {} lpp source'.\
-                      format(NIM_PARAMS['targets'], NIM_PARAMS['lpp_source']))
+    logging.info('NIM - dealloacte operation on {} for {} lpp source'
+                 .format(NIM_PARAMS['targets'], NIM_PARAMS['lpp_source']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
 
     logging.debug('NIM - Target list: {}'.format(target_list))
 
-    cmde = 'nim -o deallocate -a lpp_source={} {}'. \
-                     format(NIM_PARAMS['lpp_source'], ' '.join(target_list))
+    cmde = 'nim -o deallocate -a lpp_source={} {}'\
+           .format(NIM_PARAMS['lpp_source'], ' '.join(target_list))
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -1081,11 +1072,11 @@ def nim_deallocate(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1106,8 +1097,8 @@ def nim_bos_inst(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info('NIM - bos_inst operation on {} using {} resource group'.\
-                      format(NIM_PARAMS['targets'], NIM_PARAMS['group']))
+    logging.info('NIM - bos_inst operation on {} using {} resource group'
+                 .format(NIM_PARAMS['targets'], NIM_PARAMS['group']))
 
     target_list = expand_targets(NIM_PARAMS['targets'])
 
@@ -1118,8 +1109,8 @@ def nim_bos_inst(module):
     else:
         script = ''
 
-    cmde = 'nim -o bos_inst -a source=mksysb -a group={} {} {}'. \
-                     format(NIM_PARAMS['group'], script, ' '.join(target_list))
+    cmde = 'nim -o bos_inst -a source=mksysb -a group={} {} {}'\
+           .format(NIM_PARAMS['group'], script, ' '.join(target_list))
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -1131,11 +1122,11 @@ def nim_bos_inst(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1154,12 +1145,12 @@ def nim_define_script(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info( \
-        'NIM - define script operation for {} ressource with location {}'.\
-        format(NIM_PARAMS['resource'], NIM_PARAMS['location']))
+    logging.info(
+        'NIM - define script operation for {} ressource with location {}'
+        .format(NIM_PARAMS['resource'], NIM_PARAMS['location']))
 
-    cmde = 'nim -o define -t script -a location={} -a server=master {}'. \
-                      format(NIM_PARAMS['location'], NIM_PARAMS['resource'])
+    cmde = 'nim -o define -t script -a location={} -a server=master {}'\
+           .format(NIM_PARAMS['location'], NIM_PARAMS['resource'])
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -1171,11 +1162,11 @@ def nim_define_script(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1195,8 +1186,8 @@ def nim_remove(module):
     global NIM_CHANGED
     global NIM_OUTPUT
 
-    logging.info('NIM - remove operation on {} ressource'.\
-                                                format(NIM_PARAMS['resource']))
+    logging.info('NIM - remove operation on {} ressource'
+                 .format(NIM_PARAMS['resource']))
 
     cmde = 'nim -o remove {}'.format(NIM_PARAMS['resource'])
 
@@ -1210,11 +1201,11 @@ def nim_remove(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1235,8 +1226,8 @@ def nim_reset(module):
     global NIM_OUTPUT
 
     ret = 0
-    logging.info('NIM - reset operation on {} ressource'.\
-                                                format(NIM_PARAMS['targets']))
+    logging.info('NIM - reset operation on {} ressource'
+                 .format(NIM_PARAMS['targets']))
 
     logging.debug('NIM - force is {}'.format(NIM_PARAMS['force']))
 
@@ -1258,8 +1249,8 @@ def nim_reset(module):
             targets_discarded.append(target)
 
     if targets_discarded:
-        logging.warning('The following targets are already in a correct state: {}'. \
-                         format(','.join(targets_discarded)))
+        logging.warning('The following targets are already in a correct state: {}'
+                        .format(','.join(targets_discarded)))
 
     if targets_to_reset:
         cmde = 'nim {} -o reset {}'.format(force, ' '.join(targets_to_reset))
@@ -1274,11 +1265,11 @@ def nim_reset(module):
         logging.info("[STDERR] {}".format(stderr))
 
         if ret != 0:
-            logging.error("Error: NIM Command: {} failed with return code {}".\
-                          format(cmde, ret))
-            module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+            logging.error("Error: NIM Command: {} failed with return code {}"
+                          .format(cmde, ret))
+            module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
         NIM_CHANGED = True
 
@@ -1319,11 +1310,11 @@ def nim_reboot(module):
     logging.info("[STDERR] {}".format(stderr))
 
     if ret != 0:
-        logging.error("Error: NIM Command: {} failed with return code {}".\
-                      format(cmde, ret))
-        module.fail_json( \
-               msg="NIM Command: {} failed with return code {} => Error :{}". \
-               format(cmde, ret, stderr.split('\n')))
+        logging.error("Error: NIM Command: {} failed with return code {}"
+                      .format(cmde, ret))
+        module.fail_json(
+               msg="NIM Command: {} failed with return code {} => Error :{}"
+               .format(cmde, ret, stderr.split('\n')))
 
     NIM_CHANGED = True
     return ret
@@ -1351,9 +1342,9 @@ if __name__ == '__main__':
             location=dict(required=False, type='str'),
             group=dict(required=False, type='str'),
             force=dict(choices=['true', 'false'], default='false', type='str'),
-            action=dict(choices=['update', 'master_setup', 'check', 'compare', \
-                                 'script', 'allocate', 'deallocate', \
-                                 'bos_inst', 'define_script', 'remove', \
+            action=dict(choices=['update', 'master_setup', 'check', 'compare',
+                                 'script', 'allocate', 'deallocate',
+                                 'bos_inst', 'define_script', 'remove',
                                  'reset', 'reboot'], type='str'),
         ),
         required_if=[
@@ -1373,9 +1364,9 @@ if __name__ == '__main__':
     )
 
     # Open log file
-    logging.basicConfig(filename='/tmp/ansible_nim_debug.log', format= \
-        '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
-        level=logging.DEBUG)
+    logging.basicConfig(filename='/tmp/ansible_nim_debug.log',
+                        format='[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s',
+                        level=logging.DEBUG)
     logging.debug('*** START ***')
 
     # =========================================================================

--- a/library/aix_nim.py
+++ b/library/aix_nim.py
@@ -15,15 +15,14 @@
 # limitations under the License.
 
 ######################################################################
+"""AIX NIM: server setup, install packages, update SP or TL"""
 
-import os
 import re
-import glob
-import shutil
 import subprocess
 import threading
 import logging
 # Ansible module 'boilerplate'
+# pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
 from ansible.module_utils.basic import *
 
 
@@ -496,8 +495,8 @@ def perform_async_customization(module, lpp_source, targets):
           'NIM - perform_async_customization - lpp_spource: {}, targets: {} '.\
           format(lpp_source, targets))
 
-    cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all -a accept_licenses=yes -a async=yes {}'. \
-          format(lpp_source, targets)
+    cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all '\
+           '-a accept_licenses=yes -a async=yes {}'.format(lpp_source, targets)
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -515,7 +514,8 @@ def perform_async_customization(module, lpp_source, targets):
 
     for line in stdout.rstrip().split('\n'):
         line = line.rstrip()
-        matched = re.match(r"Either the software is already at the same level as on the media, or", line)
+        matched = re.match(r"Either the software is already at the same level as on the media, or",
+                           line)
         if matched:
             do_not_error = True
 
@@ -550,8 +550,8 @@ def perform_sync_customization(module, lpp_source, targets):
         'NIM - perform_sync_customization - lpp_spource: {}, targets: {} '.\
                                                   format(lpp_source, targets))
 
-    cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all -a accept_licenses=yes -a async=no {}'. \
-                                                  format(lpp_source, targets)
+    cmde = '/usr/sbin/nim -o cust -a lpp_source={} -a fixes=update_all '\
+           '-a accept_licenses=yes -a async=no {}'.format(lpp_source, targets)
 
     logging.debug('NIM - Command:{}'.format(cmde))
     NIM_OUTPUT.append('NIM - Command:{}'.format(cmde))
@@ -580,7 +580,8 @@ def perform_sync_customization(module, lpp_source, targets):
 
     for line in stderr.rstrip().split('\n'):
         line = line.rstrip()
-        matched = re.match(r"^Either the software is already at the same level as on the media, or", line)
+        matched = re.match(r"^Either the software is already at the same level as on the media, or",
+                           line)
         if matched:
             do_not_error = True
 
@@ -718,8 +719,8 @@ def find_resource_by_client(lpp_type, lpp_time, oslevel_elts):
         lpp_source = '{}-{}-{}-{}-lpp_source'. \
                      format(oslevel_elts[0], oslevel_elts[1], \
                             oslevel_elts[2], oslevel_elts[3])
-        logging.debug('NIM - find resource: server already to the {} {}, or no lpp_source were found, {} will be utilized'. \
-                       format(lpp_time, lpp_type, lpp_source))
+        logging.debug('NIM - find resource: server already to the {} {}, or no lpp_source were '\
+                      'found, {} will be utilized'.format(lpp_time, lpp_type, lpp_source))
     else:
         logging.debug('NIM - find resource: found the {} lpp_source, {} will be utilized'. \
                        format(lpp_time, lpp_source))
@@ -767,6 +768,8 @@ def nim_update(module):
     if NIM_PARAMS['force'] == 'true':
         for target in target_list:
             (ret, fixes) = list_fixes(target, module)
+            if ret != 0:
+                logging.info("Continue to remove as many interim fixes we can".format(cmde, ret))
             for fix in fixes:
                 remove_fix(target, fix, module)
                 logging.warning( \
@@ -780,8 +783,8 @@ def nim_update(module):
             module.fail_json(msg="NIM - Error: cannot find lpp_source {}". \
                                               format(NIM_NODE['lpp_sources']))
         else:
-            logging.info('NIM - perform asynchronous software customization for client(s) {} with resource {}'. \
-                      format(' '.join(target_list), lpp_source))
+            logging.info('NIM - perform asynchronous software customization for client(s) {} '\
+                         'with resource {}'.format(' '.join(target_list), lpp_source))
             perform_async_customization(module, lpp_source, ' '.join(target_list))
 
     else:    # synchronous update
@@ -843,8 +846,8 @@ def nim_update(module):
                 logging.info('Machine {} needs upgrade from {} to {}'. \
                                 format(target, cur_oslevel, '-'.join(oslevel_elts)))
 
-            logging.info('NIM - perform synchronous software customization for client(s) {} with resource {}'. \
-                      format(target, new_lpp_source))
+            logging.info('NIM - perform synchronous software customization for client(s) {} '\
+                         'with resource {}'.format(target, new_lpp_source))
             perform_sync_customization(module, new_lpp_source, target)
 
     NIM_CHANGED = True
@@ -1336,7 +1339,7 @@ if __name__ == '__main__':
     NIM_NODE = {}
     NIM_CHANGED = False
 
-    module = AnsibleModule(
+    MODULE = AnsibleModule(
         argument_spec=dict(
             description=dict(required=False, type='str'),
             lpp_source=dict(required=False, type='str'),
@@ -1378,19 +1381,19 @@ if __name__ == '__main__':
     # =========================================================================
     # Get Module params
     # =========================================================================
-    lpp_source = module.params['lpp_source']
-    targets = module.params['targets']
-    async_par = module.params['async']
-    device = module.params['device']
-    script = module.params['script']
-    resource = module.params['resource']
-    location = module.params['location']
-    group = module.params['group']
-    force = module.params['force']
-    action = module.params['action']
+    lpp_source = MODULE.params['lpp_source']
+    targets = MODULE.params['targets']
+    async_par = MODULE.params['async']
+    device = MODULE.params['device']
+    script = MODULE.params['script']
+    resource = MODULE.params['resource']
+    location = MODULE.params['location']
+    group = MODULE.params['group']
+    force = MODULE.params['force']
+    action = MODULE.params['action']
 
-    if module.params['description']:
-        description = module.params['description']
+    if MODULE.params['description']:
+        description = MODULE.params['description']
     else:
         description = "NIM operation: {} request".format(action)
 
@@ -1400,7 +1403,7 @@ if __name__ == '__main__':
     # =========================================================================
     # build nim node info
     # =========================================================================
-    build_nim_node(module)
+    build_nim_node(MODULE)
 
     logging.info('NIM - action {}'.format(action))
 
@@ -1409,67 +1412,67 @@ if __name__ == '__main__':
         NIM_PARAMS['lpp_source'] = lpp_source
         NIM_PARAMS['async'] = async_par
         NIM_PARAMS['force'] = force
-        nim_update(module)
+        nim_update(MODULE)
 
     elif action == 'master_setup':
         NIM_PARAMS['device'] = device
-        nim_master_setup(module)
+        nim_master_setup(MODULE)
 
     elif action == 'check':
         nim_check()
 
     elif action == 'compare':
         NIM_PARAMS['targets'] = targets
-        nim_compare(module)
+        nim_compare(MODULE)
 
     elif action == 'script':
         NIM_PARAMS['targets'] = targets
         NIM_PARAMS['script'] = script
         NIM_PARAMS['async'] = async_par
-        nim_script(module)
+        nim_script(MODULE)
 
     elif action == 'allocate':
         NIM_PARAMS['targets'] = targets
         NIM_PARAMS['lpp_source'] = lpp_source
-        nim_allocate(module)
+        nim_allocate(MODULE)
 
     elif action == 'deallocate':
         NIM_PARAMS['targets'] = targets
         NIM_PARAMS['lpp_source'] = lpp_source
-        nim_deallocate(module)
+        nim_deallocate(MODULE)
 
     elif action == 'bos_inst':
         NIM_PARAMS['targets'] = targets
         NIM_PARAMS['group'] = group
         NIM_PARAMS['script'] = script
-        nim_bos_inst(module)
+        nim_bos_inst(MODULE)
 
     elif action == 'define_script':
         NIM_PARAMS['resource'] = resource
         NIM_PARAMS['location'] = location
-        nim_define_script(module)
+        nim_define_script(MODULE)
 
     elif action == 'remove':
         NIM_PARAMS['resource'] = resource
-        nim_remove(module)
+        nim_remove(MODULE)
 
     elif action == 'reset':
         NIM_PARAMS['targets'] = targets
         NIM_PARAMS['force'] = force
-        ret = nim_reset(module)
+        ret = nim_reset(MODULE)
 
     elif action == 'reboot':
         NIM_PARAMS['targets'] = targets
-        ret = nim_reboot(module)
+        ret = nim_reboot(MODULE)
 
     else:
         logging.error('NIM - Error: Unknowned action {}'.format(action))
-        module.fail_json(msg='NIM - Error: Unknowned action {}'.format(action))
+        MODULE.fail_json(msg='NIM - Error: Unknowned action {}'.format(action))
 
     # ==========================================================================
     # Exit
     # ==========================================================================
-    module.exit_json(
+    MODULE.exit_json(
         changed=NIM_CHANGED,
         msg="NIM {} completed successfully".format(action),
         debug_output=DEBUG_DATA,

--- a/library/aix_nim_updateios.py
+++ b/library/aix_nim_updateios.py
@@ -16,12 +16,8 @@
 
 ############################################################################
 
-import os
 import re
-import glob
-import shutil
 import subprocess
-import threading
 import logging
 import time
 
@@ -60,7 +56,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
     output = ''
 
     logging.debug('exec command:{}'.format(cmd))
-    if debug_data == True:
+    if debug_data is True:
         DEBUG_DATA.append('exec command:{}'.format(cmd))
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
@@ -69,7 +65,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         # exception for ret_code != 0 can be cached if exit_on_error is set
         output = exc.output
         ret_code = exc.returncode
-        if exit_on_error == True:
+        if exit_on_error is True:
             msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'. \
                     format(cmd, exc.cmd, ret_code, output)
             module.fail_json(msg=msg)
@@ -81,11 +77,11 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         module.fail_json(msg=msg)
 
     if ret_code == 0:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec output:{}'.format(output))
         logging.debug('exec command output:{}'.format(output))
     else:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
         logging.debug('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
 
@@ -103,7 +99,6 @@ def get_nim_clients_info(module, lpar_type):
            nim master and their associated cstate value
     """
     std_out = ''
-    std_err = ''
     info_hash = {}
 
     cmd = ['lsnim', '-t', lpar_type, '-l']
@@ -135,8 +130,8 @@ def get_nim_clients_info(module, lpar_type):
                     info_hash[obj_key]['mgmt_vios_id'] = mgmt_elts[1]
                     info_hash[obj_key]['mgmt_cec_serial'] = mgmt_elts[2]
                 else:
-                    logging.warning('WARNING: VIOS {} management profile has not 3 elements: {}'. \
-                                  format(obj_key, match_mgmtprof.group(1)))
+                    logging.warning('WARNING: VIOS {} management profile has not 3 elements: {}'.
+                                    format(obj_key, match_mgmtprof.group(1)))
                 continue
 
             match_if = re.match(r"^\s+if1\s+=\s+\S+\s+(\S+)\s+.*$", line)
@@ -189,15 +184,18 @@ def check_lpp_source(module, lpp_source):
     (ret, std_out) = exec_cmd(cmd, module)
     if ret != 0:
         logging.error('NIM - Error: cannot find location of lpp_source {}'.format(lpp_source))
-        module.fail_json(msg="NIM - Error: cannot find location of lpp_source {}".format(lpp_source))
+        module.fail_json(msg="NIM - Error: cannot find location of lpp_source {}"
+                         .format(lpp_source))
     location = std_out.split()[3]
 
     # check to make sure path exists
     cmd = ['/bin/find/', location]
     (ret, std_out) = exec_cmd(cmd, module)
     if ret != 0:
-        logging.error('NIM - Error: cannot find location of lpp_source {}'.format(lpp_source))
-        module.fail_json(msg="NIM - Error: cannot find location of lpp_source {}".format(lpp_source))
+        logging.error('NIM - Error: cannot find location of lpp_source {}'
+                      .format(lpp_source))
+        module.fail_json(msg="NIM - Error: cannot find location of lpp_source {}"
+                         .format(lpp_source))
 
     return True
 
@@ -232,25 +230,24 @@ def check_vios_targets(module, targets):
         tuple_len = len(tuple_elts)
 
         if tuple_len != 1 and tuple_len != 2:
-            OUTPUT.append('Malformed VIOS targets {}. Tuple {} should be a 1 or 2 elements.'. \
-                          format(targets, tuple_elts))
-            logging.error('Malformed VIOS targets {}. Tuple {} should be a 1 or 2 elements.'. \
-                          format(targets, tuple_elts))
+            OUTPUT.append('Malformed VIOS targets {}. Tuple {} should be a 1 or 2 elements.'
+                          .format(targets, tuple_elts))
+            logging.error('Malformed VIOS targets {}. Tuple {} should be a 1 or 2 elements.'
+                          .format(targets, tuple_elts))
             return None
 
         # check vios not already exists in the target list
         if tuple_elts[0] in vios_list or \
-           (tuple_len == 2 and (tuple_elts[1] in vios_list or \
-                                tuple_elts[0] == tuple_elts[1])):
-            OUTPUT.append('Malformed VIOS targets {}. Duplicated VIOS'. \
-                          format(targets))
-            logging.error('Malformed VIOS targets {}. Duplicated VIOS'. \
-                          format(targets))
+           (tuple_len == 2 and (tuple_elts[1] in vios_list or tuple_elts[0] == tuple_elts[1])):
+            OUTPUT.append('Malformed VIOS targets {}. Duplicated VIOS'
+                          .format(targets))
+            logging.error('Malformed VIOS targets {}. Duplicated VIOS'
+                          .format(targets))
             return None
 
         # check vios is knowed by the NIM master - if not ignore it
         if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
-           (tuple_len == 2 and  tuple_elts[1] not in NIM_NODE['nim_vios']):
+           (tuple_len == 2 and tuple_elts[1] not in NIM_NODE['nim_vios']):
             continue
 
         if tuple_len == 2:
@@ -266,6 +263,7 @@ def check_vios_targets(module, targets):
             vios_list_tuples_res.append(tuple(my_tuple))
 
     return vios_list_tuples_res
+
 
 # ----------------------------------------------------------------
 # ----------------------------------------------------------------
@@ -283,7 +281,6 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
 
     ssp_name = ''
     vios_ssp_status = ''
-    vios_name = ''
     err_label = 'FAILURE-SSP'
     cluster_found = False
     tuple_len = len(target_tuple)
@@ -293,17 +290,17 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
 
     # get the SSP status
     for vios in target_tuple:
-        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', \
-               NIM_NODE['nim_vios'][vios]['vios_ip'], \
+        cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
+               NIM_NODE['nim_vios'][vios]['vios_ip'],
                '"/usr/ios/cli/ioscli cluster -status -fmt :"']
         (ret, std_out) = exec_cmd(cmd, module)
 
         if ret != 0:
             update_op_tab[vios_key] = err_label
-            OUTPUT.append('    Failed to get the SSP status for {}, cluster status returns: {}'. \
-                          format(vios, std_out))
-            logging.error('Failed to get the SSP status for {}, cluster status returns: {} {}'. \
-                          format(vios, ret, std_out))
+            OUTPUT.append('    Failed to get the SSP status for {}, cluster status returns: {}'
+                          .format(vios, std_out))
+            logging.error('Failed to get the SSP status for {}, cluster status returns: {} {}'
+                          .format(vios, ret, std_out))
             return 1
 
         # check that the VIOSes belong to the same cluster and have the same satus
@@ -318,8 +315,8 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
             line = line.rstrip()
             match_key = re.match(r"^Cluster does not exist.$", line)
             if match_key:
-                logging.debug('There is no cluster or the node {} is DOWN'. \
-                              format(vios))
+                logging.debug('There is no cluster or the node {} is DOWN'
+                              .format(vios))
                 NIM_NODE['nim_vios'][vios]['vios_ssp_status'] = 'DOWN'
                 if tuple_len == 1:
                     return 0
@@ -330,7 +327,7 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
             match_key = re.match(r"^(\S+):(\S+):(\S+):\S+:\S+:(\S+):.*", line)
             if match_key:
                 cur_ssp_name = match_key.group(1)
-                cur_ssp_satus = match_key.group(2)
+                # cur_ssp_satus = match_key.group(2)
                 cur_vios_name = match_key.group(3)
                 cur_vios_ssp_status = match_key.group(4)
 
@@ -340,8 +337,9 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
                     # single VIOS case
                     if tuple_len == 1:
                         if cur_vios_ssp_status == 'OK':
-                            err_msg = 'SSP is active for the single VIOS: {}. VIOS cannot be updated'. \
-                                       format(cur_vios_name)
+                            err_msg = 'SSP is active for the single VIOS: {}.'\
+                                      'VIOS cannot be updated'\
+                                      .format(cur_vios_name)
                             OUTPUT.append('{}'.format(err_msg))
                             logging.error('{}'.format(err_msg))
                             update_op_tab[vios_key] = err_label
@@ -352,21 +350,22 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
                     # first VIOS in the pair
                     if ssp_name == "":
                         ssp_name = cur_ssp_name
-                        vios_name = cur_vios_name
                         vios_ssp_status = cur_vios_ssp_status
                         continue
 
                     # both VIOSes found
                     if vios_ssp_status != cur_vios_ssp_status:
-                        err_msg = 'SSP status is not the same for the both VIOSes: ({}). VIOSes cannot be updated'. \
-                                   format(vios_key)
+                        err_msg = 'SSP status is not the same for the both VIOSes: ({}).'\
+                                  ' VIOSes cannot be updated'\
+                                  .format(vios_key)
                         OUTPUT.append('{}'.format(err_msg))
                         logging.error('{}'.format(err_msg))
                         update_op_tab[vios_key] = err_label
                         return 1
                     elif ssp_name != cur_ssp_name and cur_vios_ssp_status == 'OK':
-                        err_msg = 'Both VIOSes: {} does not belong to the same SSP. VIOSes cannot be updated'. \
-                                   format(vios_key)
+                        err_msg = 'Both VIOSes: {} does not belong to the same SSP.'\
+                                  ' VIOSes cannot be updated'\
+                                  .format(vios_key)
                         OUTPUT.append('{}'.format(err_msg))
                         logging.error('{}'.format(err_msg))
                         update_op_tab[vios_key] = err_label
@@ -374,9 +373,8 @@ def get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab):
                     else:
                         return 0
 
-    if cluster_found == True:
-        err_msg = 'Only one VIOS belongs to an SSP. VIOSes {} cannot be updated'. \
-                                   format(vios_key)
+    if cluster_found is True:
+        err_msg = 'Only one VIOS belongs to an SSP. VIOSes {} cannot be updated'.format(vios_key)
         OUTPUT.append('{}'.format(err_msg))
         logging.error('{}'.format(err_msg))
         update_op_tab[vios_key] = err_label
@@ -404,23 +402,24 @@ def ssp_stop_start(module, target_tuple, vios, action):
     if action == "start":
         logging.debug("search the vios runing ssp")
         for cur_node in target_tuple:
-            logging.debug("vios:{} ssp status is {}".format(cur_node, NIM_NODE['nim_vios'][cur_node]['vios_ssp_status']))
+            logging.debug("vios:{} ssp status is {}".
+                          format(cur_node, NIM_NODE['nim_vios'][cur_node]['vios_ssp_status']))
 
             if NIM_NODE['nim_vios'][cur_node]['vios_ssp_status'] == "OK":
                 node = cur_node
                 break
 
-    clctrl_cmd = '/usr/sbin/clctrl -{} -n {} -m {}'. \
-                 format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios)
+    clctrl_cmd = '/usr/sbin/clctrl -{} -n {} -m {}'\
+                 .format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios)
 
-    cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', \
-            NIM_NODE['nim_vios'][node]['vios_ip'], \
-            '"%s"' %(clctrl_cmd )]
+    cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh',
+           NIM_NODE['nim_vios'][node]['vios_ip'],
+           '"%s"' % (clctrl_cmd)]
     (ret, std_out) = exec_cmd(cmd, module)
 
     if ret != 0:
-        msg = 'Failed to {} cluster {} on vios {}'. \
-              format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios)
+        msg = 'Failed to {} cluster {} on vios {}'\
+              .format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios)
         logging.warn("{}".format(msg))
         return 1
 
@@ -429,8 +428,8 @@ def ssp_stop_start(module, target_tuple, vios, action):
     else:
         NIM_NODE['nim_vios'][vios]['vios_ssp_status'] = 'OK'
 
-    logging.info('{} cluster {} on vios {} succeed'. \
-                 format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios))
+    logging.info('{} cluster {} on vios {} succeed'
+                 .format(action, NIM_NODE['nim_vios'][vios]['ssp_name'], vios))
 
     return 0
 
@@ -452,37 +451,38 @@ def get_updateios_cmd(module):
     # lpp source
     if module.params['lpp_source']:
         if (check_lpp_source(module, module.params['lpp_source'])):
-            cmd += ['-a', 'lpp_source=%s' %(module.params['lpp_source'])]
+            cmd += ['-a', 'lpp_source=%s' % (module.params['lpp_source'])]
 
     # accept licenses
     if module.params['accept_licenses']:
-        cmd += ['-a', 'accept_licenses=%s' %(module.params['accept_licenses'])]
-    else: #default
+        cmd += ['-a', 'accept_licenses=%s' % (module.params['accept_licenses'])]
+    else:  # default
         cmd += ['-a', 'accept_licenses=yes']
 
     # updateios flags
-    cmd += ['-a', 'updateios_flags=-%s' %(module.params['action'])]
+    cmd += ['-a', 'updateios_flags=-%s' % (module.params['action'])]
 
     if module.params['action'] == "remove":
         if module.params['filesets']:
-            cmd += ['-a', 'filesets=%s' %(module.params['filesets'])]
+            cmd += ['-a', 'filesets=%s' % (module.params['filesets'])]
         elif module.params['installp_bundle']:
-            cmd += ['-a', 'installp_bundle=%s' %(module.params['installp_bundle'])]
+            cmd += ['-a', 'installp_bundle=%s' % (module.params['installp_bundle'])]
         else:
-            msg = '"filesets" parameter or "installp_bundle" parameter is mandatory with the "remove" action'
+            msg = '"filesets" parameter or "installp_bundle" parameter'\
+                  'is mandatory with the "remove" action'
             logging.error('{}'.format(msg))
             OUTPUT.append('{}'.format(msg))
             module.fail_json(msg=msg)
     else:
         if module.params['filesets'] or module.params['installp_bundle']:
-            logging.info('Discarding filesets {} and installp_bundle {}'. \
-                         format(module.params['filesets'], module.params['installp_bundle']))
+            logging.info('Discarding filesets {} and installp_bundle {}'
+                         .format(module.params['filesets'], module.params['installp_bundle']))
             OUTPUT.append('Any installp_bundle or filesets have been discarded')
 
     # preview mode
     if module.params['preview']:
-        cmd += ['-a', 'preview=%s' %(module.params['preview'])]
-    else: #default
+        cmd += ['-a', 'preview=%s' % (module.params['preview'])]
+    else:  # default
         cmd += ['-a', 'preview=yes']
 
     return cmd
@@ -523,46 +523,48 @@ def nim_updateios(module, targets_list, vios_status, update_op_tab, time_limit):
         if not (vios_status is None):
             if vios_key not in vios_status:
                 update_op_tab[vios_key] = "FAILURE-NO-PREV-STATUS"
-                OUTPUT.append("    {} vioses skipped (no previous status found)". \
-                               format(vios_key))
-                logging.warn("{} vioses skipped (no previous status found)". \
-                              format(vios_key))
+                OUTPUT.append("    {} vioses skipped (no previous status found)"
+                              .format(vios_key))
+                logging.warn("{} vioses skipped (no previous status found)"
+                             .format(vios_key))
                 continue
 
             elif vios_status[vios_key] != 'SUCCESS-ALTDC':
                 update_op_tab[vios_key] = vios_status[vios_key]
-                OUTPUT.append("    {} vioses skipped (vios_status: {})". \
-                               format(vios_key, vios_status[vios_key]))
-                logging.warn("{} vioses skipped (vios_status: {})". \
-                              format(vios_key, vios_status[vios_key]))
+                OUTPUT.append("    {} vioses skipped (vios_status: {})"
+                              .format(vios_key, vios_status[vios_key]))
+                logging.warn("{} vioses skipped (vios_status: {})"
+                             .format(vios_key, vios_status[vios_key]))
                 continue
 
         # check if there is time to handle this tuple
         if not (time_limit is None) and time.localtime(time.time()) >= time_limit:
             time_limit_str = time.strftime("%m/%d/%Y %H:%M", time_limit)
-            OUTPUT.append("    Time limit {} reached, no further operation". \
-                    format(time_limit_str))
-            logging.info('Time limit {} reached, no further operation'. \
-                    format(time_limit_str))
+            OUTPUT.append("    Time limit {} reached, no further operation"
+                          .format(time_limit_str))
+            logging.info('Time limit {} reached, no further operation'
+                         .format(time_limit_str))
             return 0
 
         # check if SSP is defined for this VIOSes tuple.
         ret = get_vios_ssp_status(module, target_tuple, vios_key, update_op_tab)
         if ret == 1:
-            logging.warn('Update operation for {} vioses skipped due to bad SSP status'. \
-                           format(vios_key))
-            OUTPUT.append('Update operation for {} vioses skipped due to bad SSP status'. \
-                           format(vios_key))
-            logging.info('Update operation can only be done when both of the VIOSes have the same SSP status (or for a single VIOS, when the SSP status is inactive) and belong to the same SSP')
+            logging.warn('Update operation for {} vioses skipped due to bad SSP status'
+                         .format(vios_key))
+            OUTPUT.append('Update operation for {} vioses skipped due to bad SSP status'
+                          .format(vios_key))
+            logging.info('Update operation can only be done when both of the VIOSes have'
+                         ' the same SSP status (or for a single VIOS, when the SSP status'
+                         ' is inactive) and belong to the same SSP')
             continue
 
         # TBC - Begin: Uncomment for testing without effective update operation
-        #OUTPUT.append('Warning: testing without effective update operation')
-        #OUTPUT.append('NIM Command: {} '.format(cmd))
-        #ret = 0
-        #std_out = 'NIM Command: {} '.format(cmd)
-        #update_op_tab[vios_key] = "SUCCESS-UPDT"
-        #continue
+        # OUTPUT.append('Warning: testing without effective update operation')
+        # OUTPUT.append('NIM Command: {} '.format(cmd))
+        # ret = 0
+        # std_out = 'NIM Command: {} '.format(cmd)
+        # update_op_tab[vios_key] = "SUCCESS-UPDT"
+        # continue
         # TBC - End
 
         update_op_tab[vios_key] = "SUCCESS-UPDT"
@@ -580,12 +582,12 @@ def nim_updateios(module, targets_list, vios_status, update_op_tab, time_limit):
             if NIM_NODE['nim_vios'][vios]['vios_ssp_status'] == 'OK':
                 ret = ssp_stop_start(module, target_tuple, vios, 'stop')
                 if ret == 1:
-                    logging.error('SSP stop operation failure for VIOS {}'. \
-                                  format(vios))
+                    logging.error('SSP stop operation failure for VIOS {}'
+                                  .format(vios))
                     update_op_tab[vios_key] = err_label
-                    logging.info('VIOS update status for {}: {}'. \
-                                 format(vios_key, update_op_tab[vios_key]))
-                    break # cannot continue
+                    logging.info('VIOS update status for {}: {}'
+                                 .format(vios_key, update_op_tab[vios_key]))
+                    break  # cannot continue
                 else:
                     restart_needed = True
                     logging.info(' {}: {}'.format(vios_key, update_op_tab[vios_key]))
@@ -610,12 +612,12 @@ def nim_updateios(module, targets_list, vios_status, update_op_tab, time_limit):
             if restart_needed:
                 ret = ssp_stop_start(module, target_tuple, vios, 'start')
                 if ret == 1:
-                    logging.error('SSP start operation failure for VIOS {}'. \
-                                  format(vios))
+                    logging.error('SSP start operation failure for VIOS {}'
+                                  .format(vios))
                     update_op_tab[vios_key] = err_label
-                    logging.info('VIOS update status for {}: {}'. \
-                                 format(vios_key, update_op_tab[vios_key]))
-                    break # cannot continue
+                    logging.info('VIOS update status for {}: {}'
+                                 .format(vios_key, update_op_tab[vios_key]))
+                    break  # cannot continue
 
                 logging.info(' {}: {}'.format(vios_key, update_op_tab[vios_key]))
 
@@ -642,9 +644,8 @@ if __name__ == '__main__':
             installp_bundle=dict(required=False, type='str'),
             lpp_source=dict(required=False, type='str'),
             accept_licenses=dict(required=False, type='str'),
-            action=dict(choices=['install', 'commit', 'reject', \
-                                          'cleanup', 'remove'], \
-                                 required=True, type='str'),
+            action=dict(choices=['install', 'commit', 'reject', 'cleanup', 'remove'],
+                        required=True, type='str'),
             preview=dict(required=False, type='str'),
             time_limit=dict(required=False, type='str'),
             vars=dict(required=False, type='dict'),
@@ -674,7 +675,8 @@ if __name__ == '__main__':
     # build a time structure for time_limit attribute,
     time_limit = None
     if module.params['time_limit']:
-        match_key = re.match(r"^\s*\d{2}/\d{2}/\d{4} \S*\d{2}:\d{2}\s*$", module.params['time_limit'])
+        match_key = re.match(r"^\s*\d{2}/\d{2}/\d{4} \S*\d{2}:\d{2}\s*$",
+                             module.params['time_limit'])
         if match_key:
             time_limit = time.strptime(module.params['time_limit'], '%m/%d/%Y %H:%M')
         else:
@@ -686,20 +688,18 @@ if __name__ == '__main__':
     LOGNAME = '/tmp/ansible_updateios_debug.log'
     if module.params['vars']:
         VARS = module.params['vars']
-    if not VARS == None and not VARS.has_key('log_file'):
+    if VARS is not None and 'log_file' not in VARS:
         VARS['log_file'] = LOGNAME
 
     # Open log file
     DEBUG_DATA.append('Log file: {}'.format(VARS['log_file']))
     LOGFRMT = '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s'
-    logging.basicConfig(filename="{}".format(VARS['log_file']), \
-            format=LOGFRMT, level=logging.DEBUG)
+    logging.basicConfig(filename="{}".format(VARS['log_file']), format=LOGFRMT, level=logging.DEBUG)
 
     logging.debug('*** START NIM UPDATE VIOS OPERATION ***')
 
     OUTPUT.append('Updateios operation for {}'.format(module.params['targets']))
-    logging.info('Action {} for {} targets'. \
-            format(module.params['action'], targets))
+    logging.info('Action {} for {} targets'.format(module.params['action'], targets))
 
     # =========================================================================
     # build nim node info
@@ -709,25 +709,22 @@ if __name__ == '__main__':
     else:
         build_nim_node(module)
 
-
     # =========================================================================
     # Perfom checks
     # =========================================================================
     ret = check_vios_targets(module, targets)
     if (ret is None) or (not ret):
         OUTPUT.append('Empty target list')
-        logging.warn('Warning: Empty target list: "{}"'. \
-                      format(targets))
+        logging.warn('Warning: Empty target list: "{}"'.format(targets))
     else:
         targets_list = ret
         OUTPUT.append('Targets list:{}'.format(targets_list))
         logging.debug('Target list: {}'.format(targets_list))
 
-
         # =========================================================================
         # Perfom the update
         # =========================================================================
-        ret = nim_updateios(module, targets_list, vios_status, \
+        ret = nim_updateios(module, targets_list, vios_status,
                             targets_update_status, time_limit)
 
         if len(targets_update_status) != 0:
@@ -746,9 +743,9 @@ if __name__ == '__main__':
     # Exit
     # =========================================================================
     module.exit_json(
-        changed = CHANGED,
-        msg = "NIM updateios operation completed successfully",
-        targets = module.params['targets'],
-        debug_output = DEBUG_DATA,
-        output = OUTPUT,
-        status = targets_update_status)
+        changed=CHANGED,
+        msg="NIM updateios operation completed successfully",
+        targets=module.params['targets'],
+        debug_output=DEBUG_DATA,
+        output=OUTPUT,
+        status=targets_update_status)

--- a/library/aix_nim_updateios.py
+++ b/library/aix_nim_updateios.py
@@ -68,14 +68,14 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         output = exc.output
         ret_code = exc.returncode
         if exit_on_error is True:
-            msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'. \
-                    format(cmd, exc.cmd, ret_code, output)
+            msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'\
+                  .format(cmd, exc.cmd, ret_code, output)
             module.fail_json(msg=msg)
 
     except OSError as exc:
         # uncatched exception
-        msg = 'Command: {} Exception.Args{}'. \
-               format(cmd, exc.args)
+        msg = 'Command: {} Exception.Args{}'\
+              .format(cmd, exc.args)
         module.fail_json(msg=msg)
 
     if ret_code == 0:
@@ -105,6 +105,9 @@ def get_nim_clients_info(module, lpar_type):
 
     cmd = ['lsnim', '-t', lpar_type, '-l']
     (ret, std_out) = exec_cmd(cmd, module)
+    if ret != 0:
+        logging.error('Error: Cannot list NIM {} objects'.format(lpar_type))
+        module.fail_json(msg="Error: Cannot list NIM {} objects".format(lpar_type))
 
     # lpar name and associated Cstate
     obj_key = ""
@@ -239,8 +242,8 @@ def check_vios_targets(targets):
             return None
 
         # check vios not already exists in the target list
-        if tuple_elts[0] in vios_list or \
-           (tuple_len == 2 and (tuple_elts[1] in vios_list or tuple_elts[0] == tuple_elts[1])):
+        if tuple_elts[0] in vios_list or (tuple_len == 2
+           and (tuple_elts[1] in vios_list or tuple_elts[0] == tuple_elts[1])):
             OUTPUT.append('Malformed VIOS targets {}. Duplicated VIOS'
                           .format(targets))
             logging.error('Malformed VIOS targets {}. Duplicated VIOS'
@@ -248,8 +251,8 @@ def check_vios_targets(targets):
             return None
 
         # check vios is knowed by the NIM master - if not ignore it
-        if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
-           (tuple_len == 2 and tuple_elts[1] not in NIM_NODE['nim_vios']):
+        if tuple_elts[0] not in NIM_NODE['nim_vios'] \
+           or (tuple_len == 2 and tuple_elts[1] not in NIM_NODE['nim_vios']):
             continue
 
         if tuple_len == 2:
@@ -679,8 +682,8 @@ if __name__ == '__main__':
         if match_key:
             time_limit = time.strptime(MODULE.params['time_limit'], '%m/%d/%Y %H:%M')
         else:
-            msg = 'Malformed time limit "{}", please use mm/dd/yyyy hh:mm format.'. \
-                    format(MODULE.params['time_limit'])
+            msg = 'Malformed time limit "{}", please use mm/dd/yyyy hh:mm format.'\
+                  .format(MODULE.params['time_limit'])
             MODULE.fail_json(msg=msg)
 
     # Handle playbook variables
@@ -712,7 +715,7 @@ if __name__ == '__main__':
     # Perfom checks
     # =========================================================================
     ret = check_vios_targets(targets)
-    if (ret is None) or (not ret):
+    if (not ret) or (ret is None):
         OUTPUT.append('Empty target list')
         logging.warn('Warning: Empty target list: "{}"'.format(targets))
     else:

--- a/library/aix_nim_updateios.py
+++ b/library/aix_nim_updateios.py
@@ -519,7 +519,7 @@ def nim_updateios(module, targets_list, vios_status, update_op_tab, time_limit):
 
         # if health check status is known, check the vios tuple has passed
         # the health check successfuly
-        if not vios_status is None:
+        if vios_status is not None:
             if vios_key not in vios_status:
                 update_op_tab[vios_key] = "FAILURE-NO-PREV-STATUS"
                 OUTPUT.append("    {} vioses skipped (no previous status found)"

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 ######################################################################
+"""AIX VIOS NIM ALTDISK: Create/Cleanup an alternate rootvg disk"""
 
 import os
 import re
@@ -27,6 +28,7 @@ import logging
 import string
 
 # Ansible module 'boilerplate'
+# pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
 from ansible.module_utils.basic import *
 
 

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -70,7 +70,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
     if debug_data == True:
         DEBUG_DATA.append('exec command:{}'.format(cmd))
     try:
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT) 
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
     except subprocess.CalledProcessError as exc:
         # exception for ret_code != 0 can be cached if exit_on_error is set
@@ -618,7 +618,7 @@ def find_valid_altdisk(module, action, vios_dict, vios_key, altdisk_op_tab):
                       format(vios, vios_dict[vios], PARAMS['disk_size_policy']))
 
         # hdisk specified by the user
-        else: 
+        else:
             # check the specified hdisk is large enough
             hdisk = vios_dict[vios]
             if pvs.has_key(hdisk):
@@ -714,7 +714,12 @@ def check_valid_altdisk(module, action, vios, vios_dict, vios_key, altdisk_op_ta
                     return 1
                 else:
                     vios_dict[vios] = hdisk
-        return 0
+        if vios_dict[vios]:
+            return 0
+        else:
+            OUTPUT.append('    There is no alternate install rootvg on {}'.format(vios))
+            logging.error('There is no alternate install rootvg on {}'.format(vios))
+            return 1
 
 
 # ----------------------------------------------------------------
@@ -967,8 +972,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                 std_out = ''
                 cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', \
                         NIM_NODE['nim_vios'][vios]['vios_ip'], \
-                        '"/etc/chdev -a pv=clear -l {}; /usr/bin/dd if=/dev/zero of=/dev/{}  seek=7 count=1 bs=512"'.\
-                        format(vios_dict[vios], vios_dict[vios])]
+                        '"/usr/bin/dd if=/dev/zero of=/dev/{}  seek=7 count=1 bs=512"'.format(vios_dict[vios])]
                 (ret, std_out) = exec_cmd(cmd, module)
 
                 if ret != 0:

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -67,7 +67,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
     output = ''
 
     logging.debug('exec command:{}'.format(cmd))
-    if debug_data == True:
+    if debug_data is True:
         DEBUG_DATA.append('exec command:{}'.format(cmd))
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
@@ -76,7 +76,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         # exception for ret_code != 0 can be cached if exit_on_error is set
         output = exc.output
         ret_code = exc.returncode
-        if exit_on_error == True:
+        if exit_on_error is True:
             msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'. \
                     format(cmd, exc.cmd, ret_code, output)
             module.fail_json(msg=msg)
@@ -88,11 +88,11 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         module.fail_json(msg=msg)
 
     if ret_code == 0:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec output:{}'.format(output))
         logging.debug('exec command output:{}'.format(output))
     else:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
         logging.debug('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
 

--- a/library/aix_nim_vios_alt_disk.py
+++ b/library/aix_nim_vios_alt_disk.py
@@ -1141,7 +1141,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                            '"LANG=C; /usr/sbin/unmirrorvg rootvg 2>&1"']
                     (ret, std_out) = exec_cmd(cmd, module)
 
-                    if ret != 0:  # c_rsh command fail
+                    if ret != 0:  # c_rsh command Failed
                         altdisk_op_tab[vios_key] = "{} to unmirror rootvg on {}"\
                                                    .format(err_label, vios)
                         OUTPUT.append('    Failed to unmirror rootvg on {}: {}'
@@ -1150,7 +1150,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                                       .format(vios, std_out))
                         break
                     elif std_out.find('rootvg successfully unmirrored') == -1:
-                        # unmirror command fail
+                        # unmirror command Failed
                         altdisk_op_tab[vios_key] = "{} to unmirror rootvg on {}"\
                                                    .format(err_label, vios)
                         OUTPUT.append('    Failed to unmirror rootvg on {}: {}'
@@ -1206,7 +1206,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
 
                     (ret, std_out) = exec_cmd(cmd, module)
 
-                    if ret != 0:  # c_rsh command fail
+                    if ret != 0:  # c_rsh command Failed
                         altdisk_op_tab[vios_key] = "{} to mirror rootvg on {}"\
                                                    .format(err_label, vios)
                         OUTPUT.append('    Failed to mirror rootvg on {}: {}'
@@ -1221,7 +1221,7 @@ def alt_disk_action(module, action, targets, vios_status, time_limit):
                         logging.info('Mirror rootvg on {} successful'
                                      .format(vios))
                     else:
-                        # mirror command fail
+                        # mirror command failed
                         altdisk_op_tab[vios_key] = "{} to mirror rootvg on {}"\
                                                    .format(err_label, vios)
                         OUTPUT.append('    Failed to mirror rootvg on {}: {}'

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -19,10 +19,7 @@
 
 import os
 import re
-import glob
-import shutil
 import subprocess
-import threading
 import logging
 # Ansible module 'boilerplate'
 # pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
@@ -36,6 +33,7 @@ author: "Patrice Jacquin"
 version_added: "1.0.0"
 requirements: [ AIX ]
 """
+
 
 # ----------------------------------------------------------------
 # ----------------------------------------------------------------
@@ -70,14 +68,13 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         output = exc.output
         ret_code = exc.returncode
         if exit_on_error is True:
-            msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'. \
-                    format(cmd, exc.cmd, ret_code, output)
+            msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'\
+                  .format(cmd, exc.cmd, ret_code, output)
             module.fail_json(msg=msg)
 
     except Exception as exc:
         # uncatched exception
-        msg = 'Command: {} Exception.Args{}'. \
-               format(cmd, exc.args)
+        msg = 'Command: {} Exception.Args{}'.format(cmd, exc.args)
         module.fail_json(msg=msg)
 
     if ret_code == 0:
@@ -103,7 +100,6 @@ def get_hmc_info(module):
     return a dic with hmc info
     """
     std_out = ''
-    std_err = ''
     info_hash = {}
 
     cmd = ['lsnim', '-t', 'hmc', '-l']
@@ -154,7 +150,6 @@ def get_nim_clients_info(module, lpar_type):
            nim master and their associated cstate value
     """
     std_out = ''
-    std_err = ''
     info_hash = {}
 
     cmd = ['lsnim', '-t', lpar_type, '-l']
@@ -258,23 +253,23 @@ def check_vios_targets(targets):
         tuple_len = len(tuple_elts)
 
         if tuple_len != 1 and tuple_len != 2:
-            logging.error('Malformed VIOS targets {}. Tuple {} should be a 2 or 4 elements.'. \
-                          format(targets, tuple_elts))
+            logging.error('Malformed VIOS targets {}. Tuple {} should be a 2 or 4 elements.'
+                          .format(targets, tuple_elts))
             return None
 
         # check vios not already exists in the target list
         if tuple_elts[0] in vios_list or \
-           (tuple_len == 2 and (tuple_elts[1] in vios_list or \
+           (tuple_len == 2 and (tuple_elts[1] in vios_list or
                                 tuple_elts[0] == tuple_elts[1])):
-            logging.error('Malformed VIOS targets {}. Duplicated VIOS'. \
-                          format(targets))
+            logging.error('Malformed VIOS targets {}. Duplicated VIOS'
+                          .format(targets))
             return None
 
         # check vios is known by the NIM master - if not ignore it
         if tuple_elts[0] not in NIM_NODE['nim_vios'] or \
-           (tuple_len == 2 and  tuple_elts[1] not in NIM_NODE['nim_vios']):
-            logging.debug('skipping {} as VIOS not known by the NIM master.'. \
-                        format(vios_tuple))
+           (tuple_len == 2 and tuple_elts[1] not in NIM_NODE['nim_vios']):
+            logging.debug('skipping {} as VIOS not known by the NIM master.'
+                          .format(vios_tuple))
             continue
 
         if tuple_len == 2:
@@ -303,8 +298,7 @@ def vios_health(module, mgmt_sys_uuid, hmc_ip, vios_uuids):
     """
     global NIM_NODE
 
-    logging.debug('hmc_ip: {} vios_uuids: {}'. \
-                  format(hmc_ip, vios_uuids))
+    logging.debug('hmc_ip: {} vios_uuids: {}'.format(hmc_ip, vios_uuids))
 
     # build the vioshc cmde
     cmd = ['/usr/sbin/vioshc.py', '-i', hmc_ip, '-m', mgmt_sys_uuid]
@@ -313,25 +307,21 @@ def vios_health(module, mgmt_sys_uuid, hmc_ip, vios_uuids):
 
     (ret, std_out) = exec_cmd(cmd, module)
     if ret != 0:
-        OUTPUT.append('    VIOS Health check failed, vioshc returns: {} {}'. \
-                      format(ret, std_out))
-        logging.error('VIOS Health check failed, vioshc returns: {} {}'. \
-                      format(ret, std_out))
-        msg = 'vioshc command error rc: {} output {}'.format(ret, std_out)
+        OUTPUT.append('    VIOS Health check failed, vioshc returns: {} {}'
+                      .format(ret, std_out))
+        logging.error('VIOS Health check failed, vioshc returns: {} {}'
+                      .format(ret, std_out))
         OUTPUT.append('    VIOS can NOT be updated')
-        logging.info('vioses {} can NOT be updated'. \
-                     format(vios_uuids))
-        ret=1
+        logging.info('vioses {} can NOT be updated'.format(vios_uuids))
+        ret = 1
     elif re.search(r'Pass rate of 100%', std_out, re.M):
         OUTPUT.append('    VIOS Health check passed')
-        logging.info('vioses {} can be updated'. \
-                     format(vios_uuids))
-        ret=0
+        logging.info('vioses {} can be updated'.format(vios_uuids))
+        ret = 0
     else:
         OUTPUT.append('    VIOS can NOT be updated')
-        logging.info('vioses {} can NOT be updated'. \
-                     format(vios_uuids))
-        ret=1
+        logging.info('vioses {} can NOT be updated'.format(vios_uuids))
+        ret = 1
 
     return ret
 
@@ -361,12 +351,12 @@ def vios_health_init(module, hmc_id, hmc_ip):
 
     (ret, std_out) = exec_cmd(cmd, module)
     if ret != 0:
-        OUTPUT.append('    Failed to get the VIOS information, vioshc returns: {} {}'. \
-                      format(ret, std_out))
-        logging.error('Failed to get the VIOS information, vioshc returns: {} {}'. \
-                      format(ret, std_out))
-        msg = 'Health init check failed. vioshc command error. rc:{}, error: {}'. \
-                format(ret, std_out)
+        OUTPUT.append('    Failed to get the VIOS information, vioshc returns: {} {}'
+                      .format(ret, std_out))
+        logging.error('Failed to get the VIOS information, vioshc returns: {} {}'
+                      .format(ret, std_out))
+        msg = 'Health init check failed. vioshc command error. rc:{}, error: {}'\
+              .format(ret, std_out)
         module.fail_json(msg=msg)
 
     # Parse the output and store the UUIDs
@@ -391,10 +381,10 @@ def vios_health_init(module, hmc_id, hmc_ip):
             match_key = re.match(r"^(\S+)\s+(\S+)$", line)
             if match_key:
                 cec_uuid = match_key.group(1)
-                cec_serial = match_key.group(2).replace("*","_")
+                cec_serial = match_key.group(2).replace("*", "_")
 
-                logging.debug('New managed system section:{},{}'.\
-                        format(cec_uuid, cec_serial))
+                logging.debug('New managed system section:{},{}'
+                              .format(cec_uuid, cec_serial))
                 continue
 
             # New vios section
@@ -411,15 +401,14 @@ def vios_health_init(module, hmc_id, hmc_ip):
         if match_key:
             vios_uuid = match_key.group(1)
             vios_part_id = match_key.group(2)
-            logging.debug('new vios partitionsection:{},{}'.\
-                    format(vios_uuid,vios_part_id))
+            logging.debug('new vios partitionsection:{},{}'
+                          .format(vios_uuid, vios_part_id))
 
             # retrieve the vios with the vios_part_id and the cec_serial value
             # and store the UUIDs in the dictionaries
             for vios_key in NIM_NODE['nim_vios']:
                 if NIM_NODE['nim_vios'][vios_key]['mgmt_vios_id'] == vios_part_id \
-                   and \
-                   NIM_NODE['nim_vios'][vios_key]['mgmt_cec_serial'] == cec_serial:
+                   and NIM_NODE['nim_vios'][vios_key]['mgmt_cec_serial'] == cec_serial:
                     NIM_NODE['nim_vios'][vios_key]['vios_uuid'] = vios_uuid
                     NIM_NODE['nim_vios'][vios_key]['cec_uuid'] = cec_uuid
                     break
@@ -438,8 +427,8 @@ def vios_health_init(module, hmc_id, hmc_ip):
 
         OUTPUT.append('    Bad command output for the hmc: {}'.format(hmc_id))
         logging.error('vioshc command, bad output line: {}'.format(line))
-        msg = 'Health init check failed. Bad vioshc.py command output for the {} hmc - output: {}'. \
-                format(hmc_id, line)
+        msg = 'Health init check failed. Bad vioshc.py command output for the {} hmc - output: {}'\
+              .format(hmc_id, line)
         module.fail_json(msg=msg)
 
     logging.debug('vioshc output: {}'.format(line))
@@ -479,14 +468,14 @@ def health_check(module, targets):
             vios_key = vios1
 
         logging.debug('vios1: {}'.format(vios1))
-        cec_serial = NIM_NODE['nim_vios'][vios1]['mgmt_cec_serial']
+        # cec_serial = NIM_NODE['nim_vios'][vios1]['mgmt_cec_serial']
         hmc_id = NIM_NODE['nim_vios'][vios1]['mgmt_hmc_id']
 
         if hmc_id not in NIM_NODE['nim_hmc']:
-            OUTPUT.append('    VIOS {} refers to an inexistant hmc {}'. \
-                         format(vios1, hmc_id))
-            logging.warn("VIOS {} refers to an inexistant hmc {}". \
-                         format(vios1, hmc_id))
+            OUTPUT.append('    VIOS {} refers to an inexistant hmc {}'
+                          .format(vios1, hmc_id))
+            logging.warn("VIOS {} refers to an inexistant hmc {}"
+                         .format(vios1, hmc_id))
             health_tab[vios_key] = 'FAILURE-HC'
             continue
 
@@ -495,22 +484,21 @@ def health_check(module, targets):
         vios_uuid = []
 
         # if needed call vios_health_init to get the UUIDs value
-        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] or \
-            tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
-
+        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] \
+           or tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
             OUTPUT.append('    Getting VIOS UUID')
 
             ret = vios_health_init(module, hmc_id, hmc_ip)
             if ret != 0:
-                OUTPUT.append('    Unable to get UUIDs of {} and {}, ret: {}'. \
-                             format(vios1, vios2, ret))
-                logging.warn("Unable to get UUIDs of {} and {}, ret: {}". \
-                             format(vios1, vios2, ret))
+                OUTPUT.append('    Unable to get UUIDs of {} and {}, ret: {}'
+                              .format(vios1, vios2, ret))
+                logging.warn("Unable to get UUIDs of {} and {}, ret: {}"
+                             .format(vios1, vios2, ret))
                 health_tab[vios_key] = 'FAILURE-HC'
                 continue
 
-        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] or \
-           tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
+        if 'vios_uuid' not in NIM_NODE['nim_vios'][vios1] \
+           or tup_len == 2 and 'vios_uuid' not in NIM_NODE['nim_vios'][vios2]:
             # vios uuid's not found
             OUTPUT.append('    One VIOS UUID not found')
             logging.warn("Unable to find one vios_uuid in NIM_NODE")
@@ -552,7 +540,6 @@ if __name__ == '__main__':
     targets_list = []
     VARS = {}
 
-
     module = AnsibleModule(
         argument_spec=dict(
             description=dict(required=False, type='str'),
@@ -581,12 +568,13 @@ if __name__ == '__main__':
     # Handle playbook variables
     if module.params['vars']:
         VARS = module.params['vars']
-    if not VARS == None and not VARS.has_key('log_file'):
+    if VARS is not None and 'log_file' not in VARS:
         VARS['log_file'] = '/tmp/ansible_vios_check_debug.log'
 
     # Open log file
-    logging.basicConfig(filename="{}".format(VARS['log_file']), format= \
-        '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
+    logging.basicConfig(
+        filename="{}".format(VARS['log_file']),
+        format='[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s',
         level=logging.DEBUG)
 
     logging.debug('*** START VIOS {} ***'.format(action.upper()))
@@ -604,8 +592,7 @@ if __name__ == '__main__':
     ret = check_vios_targets(targets)
     if (ret is None) or (not ret):
         OUTPUT.append('    Warning: Empty target list')
-        logging.warn('Empty target list: "{}"'. \
-                      format(targets))
+        logging.warn('Empty target list: "{}"'.format(targets))
     else:
         targets_list = ret
         OUTPUT.append('    Targets list: {}'.format(targets_list))

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -61,7 +61,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
     if debug_data == True:
         DEBUG_DATA.append('exec command:{}'.format(cmd))
     try:
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT) 
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
     except subprocess.CalledProcessError as exc:
         # exception for ret_code != 0 can be cached if exit_on_error is set
@@ -97,7 +97,7 @@ def get_hmc_info(module):
     Get the hmc info on the nim master
 
     fill the hmc_dic passed in parameter
-    
+
     return a dic with hmc info
     """
     std_out = ''
@@ -184,7 +184,7 @@ def get_nim_clients_info(module, lpar_type):
                     info_hash[obj_key]['mgmt_vios_id'] = mgmt_elts[1]
                     info_hash[obj_key]['mgmt_cec_serial'] = mgmt_elts[2]
 
-            match_if = re.match(r"^\s+if1\s+=\s+\S+\s+(\S+)\s+.*$", line) 
+            match_if = re.match(r"^\s+if1\s+=\s+\S+\s+(\S+)\s+.*$", line)
             if match_if:
                 info_hash[obj_key]['vios_ip'] = match_if.group(1)
 
@@ -390,7 +390,7 @@ def vios_health_init(module, hmc_id, hmc_ip):
             if match_key:
                 cec_uuid = match_key.group(1)
                 cec_serial = match_key.group(2).replace("*","_")
-                
+
                 logging.debug('New managed system section:{},{}'.\
                         format(cec_uuid, cec_serial))
                 continue
@@ -450,7 +450,7 @@ def health_check(module, targets):
     """
     Healt assessment of the VIOSes targets to ensure they can be support
     a rolling update operation.
-    
+
     For each VIOS tuple,
     - call /usr/sbin/vioshc.py a first time to collect the VIOS UUIDs
     - call it a second time to check the healthiness
@@ -475,7 +475,7 @@ def health_check(module, targets):
             vios_key = "{}-{}".format(vios1, vios2)
         else:
             vios_key = vios1
-        
+
         logging.debug('vios1: {}'.format(vios1))
         cec_serial = NIM_NODE['nim_vios'][vios1]['mgmt_cec_serial']
         hmc_id = NIM_NODE['nim_vios'][vios1]['mgmt_hmc_id']
@@ -488,9 +488,6 @@ def health_check(module, targets):
             health_tab[vios_key] = 'FAILURE-HC'
             continue
 
-        hmc_login = NIM_NODE['nim_hmc'][hmc_id]['login']
-        hmc_login_len = len(hmc_login)
-        hmc_passfile = NIM_NODE['nim_hmc'][hmc_id]['passwd_file']
         hmc_ip = NIM_NODE['nim_hmc'][hmc_id]['ip']
 
         vios_uuid = []
@@ -517,7 +514,7 @@ def health_check(module, targets):
             logging.warn("Unable to find one vios_uuid in NIM_NODE")
             health_tab[vios_key] = 'FAILURE-HC'
 
-        else:            
+        else:
             # run the vios_health check for the vios tuple
             vios_uuid.append(NIM_NODE['nim_vios'][vios1]['vios_uuid'])
             if tup_len == 2:
@@ -552,7 +549,7 @@ if __name__ == '__main__':
     CHANGED = False
     targets_list = []
     VARS = {}
-    
+
 
     module = AnsibleModule(
         argument_spec=dict(

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -58,7 +58,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
     output = ''
 
     logging.debug('exec command:{}'.format(cmd))
-    if debug_data == True:
+    if debug_data is True:
         DEBUG_DATA.append('exec command:{}'.format(cmd))
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
@@ -67,7 +67,7 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         # exception for ret_code != 0 can be cached if exit_on_error is set
         output = exc.output
         ret_code = exc.returncode
-        if exit_on_error == True:
+        if exit_on_error is True:
             msg = 'Command: {} Exception.Args{} =>RetCode:{} ... Error:{}'. \
                     format(cmd, exc.cmd, ret_code, output)
             module.fail_json(msg=msg)
@@ -79,11 +79,11 @@ def exec_cmd(cmd, module, exit_on_error=False, debug_data=True):
         module.fail_json(msg=msg)
 
     if ret_code == 0:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec output:{}'.format(output))
         logging.debug('exec command output:{}'.format(output))
     else:
-        if debug_data == True:
+        if debug_data is True:
             DEBUG_DATA.append('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
         logging.debug('exec command ret_code:{}, stderr:{}'.format(ret_code, output))
 

--- a/library/aix_nim_vios_hc.py
+++ b/library/aix_nim_vios_hc.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 ######################################################################
+"""AIX VIOS Health Check: check the pair of VIOS can be updated"""
 
 import os
 import re
@@ -24,6 +25,7 @@ import subprocess
 import threading
 import logging
 # Ansible module 'boilerplate'
+# pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
 from ansible.module_utils.basic import *
 
 

--- a/library/aix_suma.py
+++ b/library/aix_suma.py
@@ -342,6 +342,10 @@ def compute_rq_name(rq_type, oslevel, clients_target_oslevel):
     rq_name = ''
     if rq_type == 'Latest':
         if not clients_target_oslevel:
+            if clients_target_oslevel == 'Latest':
+                logging.error( \
+                    'Error: target oslevel cannot be "Latest" check you can get the oslevel on targets')
+                return 2
             metadata_filter_ml = oslevel[:7]
             if len(metadata_filter_ml) == 4:
                 metadata_filter_ml += "-00"
@@ -907,6 +911,12 @@ def suma_down_prev(module):
     for key in [k for (k, v) in clients_oslevel.items() if not v]:
         removed_oslevel.append(key)
         del clients_oslevel[key]
+
+    # Check we have at least one oslevel when a target is specified
+    if len(targets_list) != 0 and len(clients_oslevel) == 0:
+        msg = "SUMA Error: Cannot retrieve oslevel for any NIM client of the target list")
+        logging.error(msg)
+        module.fail_json(msg=msg)
 
     logging.debug("oslevel cleaned dict: {}".format(clients_oslevel))
     logging.warn("SUMA - unavailable client list: {}".format(removed_oslevel))

--- a/library/aix_suma.py
+++ b/library/aix_suma.py
@@ -16,6 +16,7 @@
 #
 
 ######################################################################
+"""AIX SUMA: download fixes, SP or TL on a NIM server"""
 
 import os
 import re
@@ -25,6 +26,7 @@ import subprocess
 import threading
 import logging
 # Ansible module 'boilerplate'
+# pylint: disable=wildcard-import,unused-wildcard-import,redefined-builtin
 from ansible.module_utils.basic import *
 
 

--- a/library/aix_suma.py
+++ b/library/aix_suma.py
@@ -239,8 +239,10 @@ def get_nim_clients(module):
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
         msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}". \
-                format(cmd, excep.args, std_out, std_err)
-        module.fail_json(msg=msg)
+                    format(cmd, excep.args, std_out, std_err)
+        SUMA_ERROR.append(msg)
+        logging.error(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     # nim_clients list
     for line in std_out.rstrip().split('\n'):
@@ -609,8 +611,8 @@ def suma_command(module, action):
     if ret != 0:
         logging.error("Error: suma {} command failed with return code {}". \
                       format(action, ret))
-        module.fail_json(msg="SUMA Command: {} => Error :{}". \
-                         format(suma_params, stderr.split('\n')))
+        SUMA_ERROR.append("SUMA Command: {} => Error :{}".format(suma_params, stderr.split('\n')))
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     return ret, stdout
 
@@ -641,12 +643,15 @@ def nim_command(module):
     ret, stdout, stderr = module.run_command(nim_params)
 
     if ret != 0:
-        logging.error("NIM Command: {}".format(nim_params))
-        logging.error("NIM operation failed - rc:{}".format(ret))
+        msg = "NIM Command: {}".format(nim_params)
+        logging.error(msg)
+        SUMA_ERROR.append(msg)
+        msg = "NIM operation failed - rc:{}".format(ret)
+        logging.error(msg)
+        SUMA_ERROR.append(msg)
         logging.error("{}".format(stderr))
-        SUMA_OUTPUT.append("NIM operation failed - rc:{}".format(ret))
-        module.fail_json(msg="NIM Master Command: {} => Error :{}". \
-                         format(nim_params, stderr.split('\n')))
+        SUMA_ERROR.append("{}".format(stderr))
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     return ret, stdout
 
@@ -667,7 +672,8 @@ def suma_list(module):
         msg = "SUMA Error: list command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append('List SUMA tasks:')
     SUMA_OUTPUT.append(stdout.split('\n'))
@@ -717,10 +723,10 @@ def suma_edit(module):
 
             cmde += ' -s "{}"'.format(PARAMS['sched_time'])
         else:
-            logging.error("Error: SUMA edit command: '{}' Bad schedule time".\
-                          format(cmde))
-            module.fail_json(msg="SUMA edit command: Bad schedule time {}". \
-                             format(PARAMS['sched_time']))
+            msg = "Error: SUMA edit command: '{}' Bad schedule time".format(cmde)
+            logging.error(msg)
+            SUMA_ERROR.append(msg)
+            module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     cmde += ' {}'.format(PARAMS['task_id'])
     ret, stdout, stderr = module.run_command(cmde)
@@ -729,7 +735,8 @@ def suma_edit(module):
         msg = "SUMA Error: edit command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append("Edit SUMA task {}".format(PARAMS['task_id']))
     SUMA_OUTPUT.append(stdout.split('\n'))
@@ -748,7 +755,8 @@ def suma_unschedule(module):
         msg = "SUMA Error: unschedule command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append("Unschedule suma task: {}".format(PARAMS['task_id']))
     SUMA_OUTPUT.append(stdout.split('\n'))
@@ -767,7 +775,8 @@ def suma_delete(module):
         msg = "SUMA Error: delete command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append("Delete SUMA task {}". \
                        format(PARAMS['task_id']))
@@ -787,7 +796,8 @@ def suma_config(module):
         msg = "SUMA Error: config command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append('SUMA global configuration settings:')
     SUMA_OUTPUT.append(stdout.split('\n'))
@@ -806,7 +816,8 @@ def suma_default(module):
         msg = "SUMA Error: default command: '{}' failed with return code {}". \
                format(cmde, ret)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     SUMA_OUTPUT.append('SUMA default task:')
     SUMA_OUTPUT.append(stdout.split('\n'))
@@ -837,16 +848,19 @@ def suma_down_prev(module):
         if req_oslevel == 'Latest':
             msg = 'Oslevel target could not be empty or equal "Latest" when target machine list is empty'
             logging.error(msg)
-            module.fail_json(msg=msg)
+            SUMA_ERROR.append(msg)
+            module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
         elif re.match(r"^([0-9]{4}-[0-9]{2})(-00|-00-0000)$", req_oslevel):
             msg = 'When no Service Pack is provided , a target machine list is required'
             logging.error(msg)
-            module.fail_json(msg=msg)
+            SUMA_ERROR.append(msg)
+            module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
     else:
         if re.match(r"^([0-9]{4})(|-00|-00-00|-00-00-0000)$", req_oslevel):
             msg = 'Specify a non 0 value for the Technical Level or the Service Pack'
             logging.error(msg)
-            module.fail_json(msg=msg)
+            SUMA_ERROR.append(msg)
+            module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     # =========================================================================
     # build NIM lpp_source list
@@ -857,7 +871,8 @@ def suma_down_prev(module):
         msg = "SUMA Error: Getting the lpp_source list - rc:{}, error:{}". \
               format(ret, nim_lpp_sources)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     logging.debug("lpp source list: {}".format(nim_lpp_sources))
 
@@ -879,14 +894,14 @@ def suma_down_prev(module):
 
     logging.info("SUMA - Target list: {}".format(len(targets_list)))
     logging.info("SUMA - Target clients: {}".format(len(target_clients)))
-    SUMA_OUTPUT.append("SUMA - Target list: {}".format(len(targets_list)))
 
     if len(targets_list) != 0 and len(target_clients) == 0:
         # the tagets_list doesn't match any NIM clients
         msg = "SUMA Error: The target patern '{}' does not match any NIM client". \
                format(PARAMS['targets'])
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     # =========================================================================
     # Launch threads to collect information on targeted nim clients
@@ -918,11 +933,16 @@ def suma_down_prev(module):
     if len(targets_list) != 0 and len(clients_oslevel) == 0:
         msg = "SUMA Error: Cannot retrieve oslevel for any NIM client of the target list"
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
+
+    logging.debug("oslevel cleaned dict: {}".format(clients_oslevel))
 
     if len(removed_oslevel) != 0:
-        logging.debug("oslevel cleaned dict: {}".format(clients_oslevel))
-        logging.warn("SUMA - unavailable client list: {}".format(removed_oslevel))
+        msg = "SUMA - unavailable client list: {}".format(removed_oslevel)
+        SUMA_ERROR.append(msg)
+        SUMA_OUTPUT.append(msg)
+        logging.warn(msg)
 
     # =========================================================================
     # compute SUMA request type based on oslevel property
@@ -931,7 +951,8 @@ def suma_down_prev(module):
     if rq_type == 'ERROR':
         msg = "SUMA Error: Invalid oslevel: '{}'".format(PARAMS['req_oslevel'])
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     PARAMS['RqType'] = rq_type
 
@@ -945,7 +966,8 @@ def suma_down_prev(module):
         msg = "SUMA Error: compute_rq_name - rc:{}, error:{}". \
                       format(ret, rq_name)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_OUTPUT.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     PARAMS['RqName'] = rq_name
 
@@ -964,17 +986,19 @@ def suma_down_prev(module):
         msg = "SUMA Error: There is no target machine matching the requested oslevel {}.". \
                format(rq_name[:10])
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     # ========================================================================= 
     # metadata does not match any fixes
     # =========================================================================
     if not rq_name or not rq_name.strip():
-        logging.error("SUMA - Error: oslevel {} doesn't match any fixes".\
-                      format(PARAMS['req_oslevel']))
-        module.fail_json( \
-                      msg="SUMA - Error:oslevel {} doesn't match any fixes".\
-                      format(PARAMS['req_oslevel']))
+        msg = "SUMA - Error: oslevel {} doesn't match any fixes".\
+                      format(PARAMS['req_oslevel'])
+        logging.error(msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
+
 
     logging.debug("Suma req Name: {}".format(rq_name))
 
@@ -994,7 +1018,8 @@ def suma_down_prev(module):
     if ret != 0:
         msg = "SUMA Error: compute_dl_target - {}".format(dl_target)
         logging.error(msg)
-        module.fail_json(msg=msg)
+        SUMA_ERROR.append(msg)
+        module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
     PARAMS['DLTarget'] = dl_target
 
@@ -1084,12 +1109,10 @@ def suma_down_prev(module):
                 if matched:
                     skipped = int(matched.group(1))
 
-            logging.info( \
-                  "Download summary : {} downloaded, {} failed, {} skipped". \
-                  format(downloaded, failed, skipped))
-            SUMA_OUTPUT.append( \
-                  "Download summary : {} downloaded, {} failed, {} skipped". \
-                  format(downloaded, failed, skipped))
+            msg = "Download summary : {} downloaded, {} failed, {} skipped". \
+                  format(downloaded, failed, skipped)
+            logging.info(msg)
+            SUMA_OUTPUT.append(msg)
 
             if downloaded != 0:
                 SUMA_CHANGED = True
@@ -1117,6 +1140,7 @@ if __name__ == '__main__':
 
     SUMA_CHANGED = False
     SUMA_OUTPUT = []
+    SUMA_ERROR = []
     PARAMS = {}
 
     module = AnsibleModule(

--- a/library/aix_suma.py
+++ b/library/aix_suma.py
@@ -98,8 +98,8 @@ def run_cmd(machine, result):
         cmd = ['/usr/lpp/bos.sysmgt/nim/methods/c_rsh', machine,
                '/usr/bin/oslevel -s']
 
-    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, \
-                         stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
 
     # return stdout only ... stripped!
     result[machine] = proc.communicate()[0].rstrip()
@@ -204,12 +204,12 @@ def exec_cmd(cmd):
     try:
         std_out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as excep:
-        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}". \
-                format(cmd, excep.cmd, excep.output, excep.returncode)
+        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}"\
+              .format(cmd, excep.cmd, excep.output, excep.returncode)
         return 1, msg
     except Exception as excep:
-        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}". \
-                format(cmd, excep.args, std_out, std_err)
+        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}"\
+              .format(cmd, excep.args, std_out, std_err)
         return 2, msg
 
     logging.debug("exec command Error:{}".format(std_err))
@@ -234,12 +234,12 @@ def get_nim_clients(module):
     cmd = ['lsnim', '-t', 'standalone']
 
     try:
-        proc = subprocess.Popen(cmd, shell=False, stdin=None, \
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(cmd, shell=False, stdin=None,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (std_out, std_err) = proc.communicate()
     except Exception as excep:
-        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}". \
-                    format(cmd, excep.args, std_out, std_err)
+        msg = "Command: {} Exception.Args{} =>Data:{} ... Error :{}"\
+              .format(cmd, excep.args, std_out, std_err)
         SUMA_ERROR.append(msg)
         logging.error(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -305,8 +305,7 @@ def compute_rq_type(oslevel, empty_list):
         SP     when oslevel is xxxx-xx-xx(-xxxx)
         ERROR  when oslevel is not recognized
     """
-    if (oslevel is None) or (not oslevel.strip()) or \
-                            (oslevel.upper() == 'LATEST'):
+    if oslevel is None or not oslevel.strip() or oslevel.upper() == 'LATEST':
         return 'Latest'
     if re.match(r"^([0-9]{4}-[0-9]{2})$", oslevel) and empty_list:
         return 'Latest'
@@ -347,39 +346,39 @@ def compute_rq_name(rq_type, oslevel, clients_target_oslevel):
     if rq_type == 'Latest':
         if not clients_target_oslevel:
             if clients_target_oslevel == 'Latest':
-                logging.error( \
-                    'Error: target oslevel cannot be "Latest" check you can get the oslevel on targets')
+                logging.error('Error: target oslevel cannot be "Latest"'
+                              'check you can get the oslevel on targets')
                 return 2
             metadata_filter_ml = oslevel[:7]
             if len(metadata_filter_ml) == 4:
                 metadata_filter_ml += "-00"
         else:
             # search first the bigest technical level from client list
-            tl_max = re.match( \
-                     r"^([0-9]{4}-[0-9]{2})(|-[0-9]{2}|-[0-9]{2}-[0-9]{4})$", \
-                     max_oslevel(clients_target_oslevel)).group(1)
+            tl_max = re.match(
+                r"^([0-9]{4}-[0-9]{2})(|-[0-9]{2}|-[0-9]{2}-[0-9]{4})$",
+                max_oslevel(clients_target_oslevel)).group(1)
 
             # search also the lowest technical level from client list
-            tl_min = re.match( \
-                     r"^([0-9]{4}-[0-9]{2})(|-[0-9]{2}|-[0-9]{2}-[0-9]{4})$", \
-                     min_oslevel(clients_target_oslevel)).group(1)
+            tl_min = re.match(
+                r"^([0-9]{4}-[0-9]{2})(|-[0-9]{2}|-[0-9]{2}-[0-9]{4})$",
+                min_oslevel(clients_target_oslevel)).group(1)
 
-            # warn the user if bigest and lowest tl do not belong 
+            # warn the user if bigest and lowest tl do not belong
             # to the same release
-            if re.match(r"^([0-9]{4})", tl_min).group(1) != \
-              re.match(r"^([0-9]{4})", tl_max).group(1):
-                logging.warning("Error: Release level mismatch, " \
-                                "only AIX {} SP/TL will be downloaded\n\n". \
-                                format(tl_max[:2]))
+            if re.match(r"^([0-9]{4})", tl_min).group(1) \
+               != re.match(r"^([0-9]{4})", tl_max).group(1):
+                logging.warning("Error: Release level mismatch, "
+                                "only AIX {} SP/TL will be downloaded\n\n"
+                                .format(tl_max[:2]))
 
             # tl_max is used to get metadata then to get latest SP
             metadata_filter_ml = tl_max
 
         if not metadata_filter_ml:
-            logging.error( \
-               'Error: cannot discover filter ml based on the list of targets')
-            raise Exception( \
-               'Error: cannot discover filter ml based on the list of targets')
+            logging.error(
+                'Error: cannot discover filter ml based on the list of targets')
+            raise Exception(
+                'Error: cannot discover filter ml based on the list of targets')
 
         if not os.path.exists(metadata_dir):
             os.makedirs(metadata_dir)
@@ -389,24 +388,24 @@ def compute_rq_name(rq_type, oslevel, clients_target_oslevel):
         suma_dltarget = "DLTarget={}".format(metadata_dir)
         suma_display = "DisplayName='{}'".format(PARAMS['Description'])
 
-        cmd = ['/usr/sbin/suma', '-x', '-a', 'Action=Metadata', \
-               '-a', 'RqType=Latest', '-a', suma_filterml, \
+        cmd = ['/usr/sbin/suma', '-x', '-a', 'Action=Metadata',
+               '-a', 'RqType=Latest', '-a', suma_filterml,
                '-a', suma_dltarget, '-a', suma_display]
 
         logging.debug("SUMA command:{}".format(cmd))
 
         ret, stdout = exec_cmd(cmd)
         if ret != 0:
-            logging.error("SUMA command error rc:{}, error: {}". \
-                          format(ret, stdout))
+            logging.error("SUMA command error rc:{}, error: {}"
+                          .format(ret, stdout))
             return ret, stdout
 
         logging.debug("SUMA command rc:{}".format(ret))
 
         # find latest SP build number for the highest TL
         sp_version = None
-        file_name = metadata_dir + "/installp/ppc/" + \
-                    metadata_filter_ml + "*.xml"
+        file_name = metadata_dir + "/installp/ppc/" \
+                                 + metadata_filter_ml + "*.xml"
         logging.debug("searched files: {}".format(file_name))
         files = glob.glob(file_name)
         logging.debug("found files: {}".format(files))
@@ -449,16 +448,16 @@ def compute_rq_name(rq_type, oslevel, clients_target_oslevel):
             suma_dltarget = 'DLTarget={}'.format(metadata_dir)
             suma_display = 'DisplayName="{}"'.format(PARAMS['Description'])
 
-            cmd = ['/usr/sbin/suma', '-x', '-a', 'Action=Metadata', \
-                   '-a', 'RqType=Latest', '-a', suma_filterml, \
+            cmd = ['/usr/sbin/suma', '-x', '-a', 'Action=Metadata',
+                   '-a', 'RqType=Latest', '-a', suma_filterml,
                    '-a', suma_dltarget, '-a', suma_display]
 
             logging.debug("suma command: {}".format(cmd))
 
             ret, stdout = exec_cmd(cmd)
             if ret != 0:
-                logging.error("SUMA command error rc:{}, error: {}". \
-                              format(ret, stdout))
+                logging.error("SUMA command error rc:{}, error: {}"
+                              .format(ret, stdout))
                 return ret, stdout
 
             # find SP build number
@@ -466,8 +465,8 @@ def compute_rq_name(rq_type, oslevel, clients_target_oslevel):
             cur_file = metadata_dir + "/installp/ppc/" + oslevel + ".xml"
             fic = open(cur_file, "r")
             for line in fic:
-                match_item = re.match( \
-                    r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$", \
+                match_item = re.match(
+                    r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$",
                     line)
                 if match_item:
                     sp_version = match_item.group(1)
@@ -498,10 +497,10 @@ def compute_filter_ml(clients_target_oslevel, rq_name):
             filter_ml += "-00"
     else:
         for key, value in iter(clients_target_oslevel.items()):
-            if re.match(r"^([0-9]{4})", value).group(1) == rq_name[:4] and \
-               re.match(r"^([0-9]{4}-[0-9]{2}-[0-9]{2})", value).group(1) < rq_name[:10] and \
-               (minimum_oslevel is None or value < minimum_oslevel):
-               minimum_oslevel = value
+            if re.match(r"^([0-9]{4})", value).group(1) == rq_name[:4] \
+               and re.match(r"^([0-9]{4}-[0-9]{2}-[0-9]{2})", value).group(1) < rq_name[:10] \
+               and (minimum_oslevel is None or value < minimum_oslevel):
+                minimum_oslevel = value
 
         if minimum_oslevel is not None:
             filter_ml = minimum_oslevel[:7]
@@ -561,15 +560,15 @@ def compute_dl_target(location, lpp_source, nim_lpp_sources):
 
     if loc[0] == '/':
         dl_target = "{}/{}".format(loc, lpp_source)
-        if (lpp_source in nim_lpp_sources) and \
-           (nim_lpp_sources[lpp_source] != dl_target):
+        if lpp_source in nim_lpp_sources \
+           and nim_lpp_sources[lpp_source] != dl_target:
             return 1, "SUMA Error: lpp source location mismatch. It already " \
-                      "exists a lpp source '{}' with a location different as '{}'". \
-                      format(lpp_source, dl_target)
+                      "exists a lpp source '{}' with a location different as '{}'" \
+                      .format(lpp_source, dl_target)
     else:
         if loc not in nim_lpp_sources:
-            return 1, "SUMA Error: lpp_source: '{}' does not exist". \
-                      format(loc)
+            return 1, "SUMA Error: lpp_source: '{}' does not exist" \
+                      .format(loc)
 
         dl_target = nim_lpp_sources[loc]
 
@@ -609,8 +608,8 @@ def suma_command(module, action):
     ret, stdout, stderr = module.run_command(suma_params)
 
     if ret != 0:
-        logging.error("Error: suma {} command failed with return code {}". \
-                      format(action, ret))
+        logging.error("Error: suma {} command failed with return code {}"
+                      .format(action, ret))
         SUMA_ERROR.append("SUMA Command: {} => Error :{}".format(suma_params, stderr.split('\n')))
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
@@ -669,8 +668,8 @@ def suma_list(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: list command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: list command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -717,9 +716,9 @@ def suma_edit(module):
         # schedule
         minute, hour, day, month, weekday = PARAMS['sched_time'].split(' ')
 
-        if check_time(minute, 0, 59) and check_time(hour, 0, 23) and \
-           check_time(day, 1, 31) and check_time(month, 1, 12) and \
-           check_time(weekday, 0, 6):
+        if check_time(minute, 0, 59) and check_time(hour, 0, 23) \
+           and check_time(day, 1, 31) and check_time(month, 1, 12) \
+           and check_time(weekday, 0, 6):
 
             cmde += ' -s "{}"'.format(PARAMS['sched_time'])
         else:
@@ -732,8 +731,8 @@ def suma_edit(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: edit command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: edit command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -752,8 +751,8 @@ def suma_unschedule(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: unschedule command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: unschedule command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -772,14 +771,13 @@ def suma_delete(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: delete command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: delete command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
-    SUMA_OUTPUT.append("Delete SUMA task {}". \
-                       format(PARAMS['task_id']))
+    SUMA_OUTPUT.append("Delete SUMA task {}".format(PARAMS['task_id']))
     SUMA_OUTPUT.append(stdout.split('\n'))
 
 
@@ -793,8 +791,8 @@ def suma_config(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: config command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: config command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -813,8 +811,8 @@ def suma_default(module):
     ret, stdout, stderr = module.run_command(cmde)
 
     if ret != 0:
-        msg = "SUMA Error: default command: '{}' failed with return code {}". \
-               format(cmde, ret)
+        msg = "SUMA Error: default command: '{}' failed with return code {}" \
+              .format(cmde, ret)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -839,14 +837,16 @@ def suma_down_prev(module):
     else:
         empty_list = True
     req_oslevel = PARAMS['req_oslevel']
-    if (req_oslevel is None) or (not req_oslevel.strip()) or \
-                            (req_oslevel.upper() == 'LATEST'):
+    if req_oslevel is None \
+       or not req_oslevel.strip() \
+       or req_oslevel.upper() == 'LATEST':
         req_oslevel = 'Latest'
         PARAMS['req_oslevel'] = req_oslevel
-        
-    if not targets_list: 
+
+    if not targets_list:
         if req_oslevel == 'Latest':
-            msg = 'Oslevel target could not be empty or equal "Latest" when target machine list is empty'
+            msg = 'Oslevel target could not be empty or equal "Latest" when' \
+                  ' target machine list is empty'
             logging.error(msg)
             SUMA_ERROR.append(msg)
             module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -868,8 +868,8 @@ def suma_down_prev(module):
     nim_lpp_sources = {}
     ret, nim_lpp_sources = get_nim_lpp_source()
     if ret != 0:
-        msg = "SUMA Error: Getting the lpp_source list - rc:{}, error:{}". \
-              format(ret, nim_lpp_sources)
+        msg = "SUMA Error: Getting the lpp_source list - rc:{}, error:{}" \
+              .format(ret, nim_lpp_sources)
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -897,8 +897,8 @@ def suma_down_prev(module):
 
     if len(targets_list) != 0 and len(target_clients) == 0:
         # the tagets_list doesn't match any NIM clients
-        msg = "SUMA Error: The target patern '{}' does not match any NIM client". \
-               format(PARAMS['targets'])
+        msg = "SUMA Error: The target patern '{}' does not match any NIM client" \
+              .format(PARAMS['targets'])
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -963,8 +963,8 @@ def suma_down_prev(module):
     # =========================================================================
     ret, rq_name = compute_rq_name(rq_type, PARAMS['req_oslevel'], clients_oslevel)
     if ret != 0:
-        msg = "SUMA Error: compute_rq_name - rc:{}, error:{}". \
-                      format(ret, rq_name)
+        msg = "SUMA Error: compute_rq_name - rc:{}, error:{}" \
+              .format(ret, rq_name)
         logging.error(msg)
         SUMA_OUTPUT.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
@@ -983,22 +983,21 @@ def suma_down_prev(module):
 
     if filter_ml is None:
         # no technical level found for the target machines
-        msg = "SUMA Error: There is no target machine matching the requested oslevel {}.". \
-               format(rq_name[:10])
+        msg = "SUMA Error: There is no target machine matching the requested oslevel {}." \
+              .format(rq_name[:10])
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
 
-    # ========================================================================= 
+    # =========================================================================
     # metadata does not match any fixes
     # =========================================================================
     if not rq_name or not rq_name.strip():
-        msg = "SUMA - Error: oslevel {} doesn't match any fixes".\
-                      format(PARAMS['req_oslevel'])
+        msg = "SUMA - Error: oslevel {} doesn't match any fixes" \
+              .format(PARAMS['req_oslevel'])
         logging.error(msg)
         SUMA_ERROR.append(msg)
         module.fail_json(msg=SUMA_ERROR, suma_output=SUMA_OUTPUT)
-
 
     logging.debug("Suma req Name: {}".format(rq_name))
 
@@ -1013,7 +1012,7 @@ def suma_down_prev(module):
     # =========================================================================
     # compute suma dl target based on lpp source name
     # =========================================================================
-    ret, dl_target = compute_dl_target(PARAMS['location'], lpp_source, \
+    ret, dl_target = compute_dl_target(PARAMS['location'], lpp_source,
                                        nim_lpp_sources)
     if ret != 0:
         msg = "SUMA Error: compute_dl_target - {}".format(dl_target)
@@ -1024,22 +1023,18 @@ def suma_down_prev(module):
     PARAMS['DLTarget'] = dl_target
 
     logging.debug("DL target: {}".format(dl_target))
-    
-    
-    
-    
+
     # display user message
     logging.info("The builded lpp_source will be: {}.".format(lpp_source))
     logging.info("The lpp_source location will be: {}.".format(dl_target))
-    logging.info("The lpp_source will be available to update machines from {}-00 to {}.". \
-                  format(filter_ml, rq_name))
+    logging.info("The lpp_source will be available to update machines from {}-00 to {}."
+                 .format(filter_ml, rq_name))
     if rq_type == 'Latest':
-        logging.info("{} is the Latest SP of TL {}.". \
-                     format(rq_name, filter_ml))
-    
-    PARAMS['Comments'] = '"Packages for updates from {} to {}"'. \
-                         format(filter_ml, rq_name)
+        logging.info("{} is the Latest SP of TL {}."
+                     .format(rq_name, filter_ml))
 
+    PARAMS['Comments'] = '"Packages for updates from {} to {}"'\
+                         .format(filter_ml, rq_name)
 
     # ========================================================================
     # Make lpp_source_dir='/usr/sys/inst.images/{}-lpp_source'.format(rq_name)
@@ -1073,8 +1068,8 @@ def suma_down_prev(module):
         if matched:
             skipped = int(matched.group(1))
 
-    msg = "Preview summary : {} to download, {} failed, {} skipped". \
-           format(downloaded, failed, skipped)
+    msg = "Preview summary : {} to download, {} failed, {} skipped"\
+          .format(downloaded, failed, skipped)
     logging.info(msg)
     SUMA_OUTPUT.append(msg)
 
@@ -1109,8 +1104,8 @@ def suma_down_prev(module):
                 if matched:
                     skipped = int(matched.group(1))
 
-            msg = "Download summary : {} downloaded, {} failed, {} skipped". \
-                  format(downloaded, failed, skipped)
+            msg = "Download summary : {} downloaded, {} failed, {} skipped"\
+                  .format(downloaded, failed, skipped)
             logging.info(msg)
             SUMA_OUTPUT.append(msg)
 
@@ -1130,8 +1125,8 @@ def suma_down_prev(module):
             SUMA_CHANGED = True
 
             logging.info("NIM operation succeeded - output:{}".format(stdout))
-            SUMA_OUTPUT.append("NIM operation succeeded - output:{}". \
-                               format(stdout))
+            SUMA_OUTPUT.append("NIM operation succeeded - output:{}"
+                               .format(stdout))
 
 
 ##############################################################################
@@ -1151,7 +1146,7 @@ if __name__ == '__main__':
             task_id=dict(required=False, type='str'),
             sched_time=dict(required=False, type='str'),
             action=dict(required=False,
-                        choices=['download', 'preview', 'list', 'edit', \
+                        choices=['download', 'preview', 'list', 'edit',
                                  'unschedule', 'delete', 'config', 'default'],
                         type='str', default='preview'),
             description=dict(required=False, type='str'),
@@ -1169,8 +1164,9 @@ if __name__ == '__main__':
     SUMA_CHANGED = False
 
     # Open log file
-    logging.basicConfig(filename='/tmp/ansible_suma_debug.log', format= \
-        '[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s', \
+    logging.basicConfig(
+        filename='/tmp/ansible_suma_debug.log',
+        format='[%(asctime)s] %(levelname)s: [%(funcName)s:%(thread)d] %(message)s',
         level=logging.DEBUG)
     logging.debug('*** START ***')
 
@@ -1184,7 +1180,7 @@ if __name__ == '__main__':
     targets = ''
     if 'targets' in module.params.keys():
         targets = module.params['targets']
-        if targets == None:
+        if targets is None:
             targets = ''
 
     task_id = module.params['task_id']

--- a/library/aix_suma.py
+++ b/library/aix_suma.py
@@ -916,12 +916,13 @@ def suma_down_prev(module):
 
     # Check we have at least one oslevel when a target is specified
     if len(targets_list) != 0 and len(clients_oslevel) == 0:
-        msg = "SUMA Error: Cannot retrieve oslevel for any NIM client of the target list")
+        msg = "SUMA Error: Cannot retrieve oslevel for any NIM client of the target list"
         logging.error(msg)
         module.fail_json(msg=msg)
 
-    logging.debug("oslevel cleaned dict: {}".format(clients_oslevel))
-    logging.warn("SUMA - unavailable client list: {}".format(removed_oslevel))
+    if len(removed_oslevel) != 0:
+        logging.debug("oslevel cleaned dict: {}".format(clients_oslevel))
+        logging.warn("SUMA - unavailable client list: {}".format(removed_oslevel))
 
     # =========================================================================
     # compute SUMA request type based on oslevel property


### PR DESCRIPTION
Add SSP management support for the VIOS update.
Various other fixes:
- No cleanup if no target disk is specified and there is no alternate rootvg
- Check at least one oslevel is set when targets list in not empty
- Using flake8 and pycodestyle in Travis instead of pylint