### PR TITLE
Add meta file for Galaxy compatibility.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  author: Paul Finley
+  description: Playbooks and modules that can be used to manage configurations of and deployments to AIX systems.
+  company: IBM
+
+  license: Apache License 2.0
+
+  min_ansible_version: 1.2
+
+  platforms:
+    - name: AIX
+      versions:
+        - 6.1
+        - 7.1
+        - 7.2
+
+  galaxy_tags:
+    - aix
+    - ansible
+    - automation
+    - patching
+    - nim
+    - suma
+
+dependencies: []


### PR DESCRIPTION
This change introduces a meta/main.yml file that provides metadata to Ansible Galaxy. The goal is to enable on-demand distribution of this content to anybody that's using Ansible Galaxy without affecting licensing of the content. Note that it still specifies the Apache v2 license in the metadata and will not be distributed with Ansible on installation.